### PR TITLE
Simplify dedup.py: remove dead code, tighten comments, add cardinality guard

### DIFF
--- a/src/gxassessms/consolidation/dedup.py
+++ b/src/gxassessms/consolidation/dedup.py
@@ -109,10 +109,11 @@ class UnionFindDedup:
                     finding.finding_key,
                 )
 
-        for indices in key_to_indices.values():
+        for key, indices in key_to_indices.items():
             if len(indices) > _CARDINALITY_WARN_THRESHOLD:
                 logger.warning(
-                    "Dedup key shared by %d findings; possible adapter misconfiguration",
+                    "Dedup key %r shared by %d findings; possible adapter misconfiguration",
+                    key,
                     len(indices),
                 )
             if len(indices) > 1:


### PR DESCRIPTION
## Summary

- Remove dead `if size < 0` guard in `_DisjointSet.__init__` -- caller always passes `len(findings)` after a non-empty check
- Replace mutable int counter `valid_key_count` with boolean `had_valid_key`
- Replace `indices[1:]` list slice with `range(1, len(indices))` index loop to avoid unnecessary allocation
- Add `_CARDINALITY_WARN_THRESHOLD = 50` guard that warns when a single dedup key maps to an unusually large number of findings (adapter misconfiguration signal)
- Drop redundant WHAT inline comments (five removed) and collapse verbose Algorithm docstring block in `group()` to a concise behavioral contract

## Test plan

- [ ] Existing dedup unit tests pass
- [ ] Verify cardinality warning fires in a manual test with a key shared by 51+ findings
- [ ] Confirm no regression in consolidation integration tests