### PR TITLE
refactor(payload): remove redundant schema_version and coverage copy

### DIFF
--- a/src/gxassessms/reporting/payload.py
+++ b/src/gxassessms/reporting/payload.py
@@ -75,7 +75,7 @@ def assemble_payload(
     raw_coverage = coverage_repo.get_for_engagement(engagement_id)
 
     findings = [_deserialize_json_fields(f) for f in raw_findings]
-    coverage = [dict(r) for r in raw_coverage]
+    coverage = raw_coverage
 
     merged_narratives: dict[str, str | None] = {
         "executive_summary": None,
@@ -90,7 +90,6 @@ def assemble_payload(
         metadata["config_snapshot"] = config_snapshot
 
     payload = ReportPayload(
-        schema_version="1.0.0",
         engagement_id=engagement_id,
         tenant_name=tenant_name,
         assessment_date=assessment_date,


### PR DESCRIPTION
## Summary

- Drops explicit `schema_version="1.0.0"` from `ReportPayload()` constructor -- the field already declares this as its default, so the kwarg was a redundant second source of truth
- Drops `[dict(r) for r in raw_coverage]` -- `CoverageRepo.get_for_engagement()` already returns `list[dict[str, Any]]`; the comprehension was copying dicts that were already fresh copies

## Test plan

- [ ] All 1262 existing tests pass (verified in worktree before commit)
- [ ] Pre-commit hooks (ruff, ruff-format, pyright, detect-secrets) all pass