### PR TITLE
Fix security report: heading placement and priority order

### DIFF
--- a/docs/security/gxassessms-security-best-practices-report.md
+++ b/docs/security/gxassessms-security-best-practices-report.md
@@ -108,6 +108,8 @@ CIS Controls v8.1 emphasizes software inventory, authorized software, library al
 - Filter renderers by configured format/theme before any renderer is instantiated or executed.
 - Consider isolating renderer execution in a dedicated low-privilege account or container.
 
+## Medium Severity Findings
+
 ### SBP-003: Sensitive artifacts depend on ambient filesystem permissions and default report output lands in the working directory
 
 **Impact:** On shared hosts, permissive workspaces, or weak backup policies, customer-sensitive findings, reports, archives, and config snapshots can be exposed to other local users or processes.
@@ -139,8 +141,6 @@ OWASP cryptographic storage guidance stresses layered protection for data at res
 - Apply restrictive directory permissions at creation time and verify them during preflight.
 - Default report output to an engagement-specific directory under the main data root rather than `./output`.
 - Add a preflight warning when data roots or output paths resolve to shared mounts, workspace directories, or weakly permissioned locations.
-
-## Medium Severity Findings
 
 ### SBP-004: Replay and rendering do not enforce artifact or payload size limits
 
@@ -188,7 +188,6 @@ OWASP input-validation and file-handling guidance recommends explicit size limit
 ## Priority Order
 
 1. Fix replay path confinement and hash binding first.
-2. Pin approved PowerShell module versions and verify publisher or signature before collection runs.
-3. Add plugin and renderer allowlisting plus config-based renderer filtering.
-4. Harden artifact/report directory permissions and move default report output under the protected data root.
-5. Add artifact and payload size ceilings plus preflight checks.
+2. Add plugin and renderer allowlisting plus config-based renderer filtering.
+3. Harden artifact/report directory permissions and move default report output under the protected data root.
+4. Add artifact and payload size ceilings plus preflight checks.


### PR DESCRIPTION
## Summary

- Moves `## Medium Severity Findings` heading to before SBP-003, where it belongs (SBP-003 and SBP-004 are both medium severity -- the heading was incorrectly placed before SBP-004 in PR #28)
- Removes a stray PowerShell module pinning item from the Priority Order section that had no corresponding SBP finding (PowerShell execution with `shell=False` is already documented as a positive control); renumbers remaining items 1-4 to match the four actual SBP findings

These are corrections that were missed from PR #28.

## Test plan

- [ ] Verify `## Medium Severity Findings` appears before SBP-003 and SBP-004
- [ ] Verify Priority Order has 4 items numbered 1-4 matching SBP-001 through SBP-004