### PR TITLE
refactor(persistence): replace raw path strings with named constants in artifacts.py

### DIFF
--- a/src/gxassessms/persistence/artifacts.py
+++ b/src/gxassessms/persistence/artifacts.py
@@ -8,6 +8,7 @@ engagement files after writing an audit manifest.
 
 from __future__ import annotations
 
+import glob
 import json
 import logging
 import re
@@ -102,7 +103,7 @@ class ArtifactManager:
         Scans the engagements root for a directory ending with the
         engagement ID. Raises PersistenceError if not found.
         """
-        for entry in self._engagements_root.glob(f"*-{engagement_id}"):
+        for entry in self._engagements_root.glob(f"*-{glob.escape(engagement_id)}"):
             if entry.is_dir():
                 _validate_path_within_root(entry, self._engagements_root)
                 return entry


### PR DESCRIPTION
## Summary

- Introduces `RAW_OUTPUT_DIR`, `_REPORTS_DIR`, `_ARCHIVE_NAME`, and `_RESTORE_STAGING_DIR` module-level constants, replacing 8 scattered string literals across the file
- Fixes a silent coupling bug: `archive()` `arcname` and `restore()` extracted-path reconstruction both referenced `"raw-output"` independently — a rename of one without the other would cause silent data loss; both now reference `RAW_OUTPUT_DIR`
- Replaces `iterdir()` + `endswith()` Python-side loop in `get_engagement_dir()` with `glob(f"*-{engagement_id}")`, delegating OS-level filtering
- Removes 5 what-narrating comments from `purge()` and `restore()` that restated what the code already expressed; kept the two non-obvious WHY comments intact

## Test plan

- [ ] All 1257 existing tests pass (`pytest -q`)
- [ ] Pre-commit hooks pass (ruff, ruff-format, pyright, detect-secrets)
- [ ] Verify `RAW_OUTPUT_DIR` is importable for future use in `replay.py` (follow-up noted but not done here to avoid introducing a new `pipeline → persistence` dependency without deliberate review)