### PR TITLE
fix(security-report): restore PowerShell pinning, correct SBP-003 severity

### DIFF
--- a/docs/security/gxassessms-security-best-practices-report.md
+++ b/docs/security/gxassessms-security-best-practices-report.md
@@ -108,8 +108,6 @@ CIS Controls v8.1 emphasizes software inventory, authorized software, library al
 - Filter renderers by configured format/theme before any renderer is instantiated or executed.
 - Consider isolating renderer execution in a dedicated low-privilege account or container.
 
-## Medium Severity Findings
-
 ### SBP-003: Sensitive artifacts depend on ambient filesystem permissions and default report output lands in the working directory
 
 **Impact:** On shared hosts, permissive workspaces, or weak backup policies, customer-sensitive findings, reports, archives, and config snapshots can be exposed to other local users or processes.
@@ -141,6 +139,8 @@ OWASP cryptographic storage guidance stresses layered protection for data at res
 - Apply restrictive directory permissions at creation time and verify them during preflight.
 - Default report output to an engagement-specific directory under the main data root rather than `./output`.
 - Add a preflight warning when data roots or output paths resolve to shared mounts, workspace directories, or weakly permissioned locations.
+
+## Medium Severity Findings
 
 ### SBP-004: Replay and rendering do not enforce artifact or payload size limits
 
@@ -188,6 +188,7 @@ OWASP input-validation and file-handling guidance recommends explicit size limit
 ## Priority Order
 
 1. Fix replay path confinement and hash binding first.
-2. Add plugin and renderer allowlisting plus config-based renderer filtering.
-3. Harden artifact/report directory permissions and move default report output under the protected data root.
-4. Add artifact and payload size ceilings plus preflight checks.
+2. Pin approved PowerShell module versions and verify publisher or signature before collection runs.
+3. Add plugin and renderer allowlisting plus config-based renderer filtering.
+4. Harden artifact/report directory permissions and move default report output under the protected data root.
+5. Add artifact and payload size ceilings plus preflight checks.


### PR DESCRIPTION
## Summary

- Reclassifies SBP-003 (filesystem permissions/ambient trust) as **High** severity by moving the `## Medium Severity Findings` heading to precede SBP-004
- Re-adds PowerShell module version pinning at priority #2 in the remediation roadmap (was incorrectly dropped in #33)
- Renumbers remaining priority items accordingly

## Background

PR #28 added the security docs. Gemini's review flagged that PowerShell module compromise was missing from the roadmap. PR #33 was intended to clean up #28 but went the wrong direction -- it removed the PowerShell item and misplaced the severity heading. These changes were sitting uncommitted locally as the intended correction.

## Test plan

- [ ] Verify `## Medium Severity Findings` heading appears before SBP-004 (not SBP-003)
- [ ] Verify priority order has 5 items with PowerShell pinning at #2
- [ ] Confirm no other content changed