### PR TITLE
[codex] ignore generated issue review docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ credentials/
 output/
 results/
 reports/
+docs/issue-review-*.md
 
 # Python
 __pycache__/


### PR DESCRIPTION
## What changed
Add `docs/issue-review-*.md` to `.gitignore`.

## Why
The issue review files are generated local review artifacts and should not show up as untracked changes or get included in routine commits.

## Impact
Keeps the working tree clean while preserving those review notes locally.

## Validation
- Pre-commit hooks ran during `git commit`
- Confirmed only `.gitignore` was staged and committed
