### PR TITLE
fix: ScubaGear reserved-arg guard + renderer config filtering (#58, #38)

### DIFF
--- a/src/gxassessms/adapters/_base.py
+++ b/src/gxassessms/adapters/_base.py
@@ -93,6 +93,34 @@ def parse_extra_args(
     return named_args, switches
 
 
+def check_reserved_args(
+    extra_named: dict[str, str],
+    switches: dict[str, bool],
+    reserved_args: frozenset[str],
+    adapter_name: str,
+) -> None:
+    """Reject extra_args that conflict with adapter-controlled parameters.
+
+    Uses PowerShell prefix-matching semantics: ``-OutP`` prefix-binds to
+    ``-OutPath``, so any user key that is a prefix of a reserved arg is
+    blocked.  An arg *longer* than the reserved arg passes correctly
+    (``"outpath".startswith("outpathextra")`` is False).
+
+    Raises:
+        CollectionError: If any user-provided arg (named or switch) matches
+            or is a prefix of a reserved arg (case-insensitive).
+    """
+    reserved_lower = frozenset(r.lower() for r in reserved_args)
+    conflicts = {k for k in extra_named if any(r.startswith(k.lower()) for r in reserved_lower)}
+    conflicts |= {k for k in switches if any(r.startswith(k.lower()) for r in reserved_lower)}
+    if conflicts:
+        raise CollectionError(
+            f"extra_args contains reserved {adapter_name} args that cannot be overridden: "
+            f"{sorted(conflicts)}",
+            adapter_name=adapter_name,
+        )
+
+
 def run_powershell(
     script: str,
     arguments: list[str] | None,

--- a/src/gxassessms/adapters/monkey365/adapter.py
+++ b/src/gxassessms/adapters/monkey365/adapter.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from gxassessms.adapters._base import (
+    check_reserved_args,
     load_json_file,
     parse_extra_args,
     validate_extra_args,
@@ -121,19 +122,7 @@ class Monkey365Adapter:
         if tc.extra_args:
             validated = validate_extra_args(tc.extra_args)
             extra_named, switches = parse_extra_args(validated)
-            _reserved_lower = frozenset(r.lower() for r in _RESERVED_ARGS)
-            reserved_conflicts = {
-                k for k in extra_named if any(r.startswith(k.lower()) for r in _reserved_lower)
-            }
-            reserved_conflicts |= {
-                k for k in switches if any(r.startswith(k.lower()) for r in _reserved_lower)
-            }
-            if reserved_conflicts:
-                raise CollectionError(
-                    f"extra_args contains reserved Monkey365 args that cannot be overridden: "
-                    f"{sorted(reserved_conflicts)}",
-                    adapter_name=self.tool_name,
-                )
+            check_reserved_args(extra_named, switches, _RESERVED_ARGS, self.tool_name)
             named_args.update(extra_named)
 
         override = getattr(tc, "module_policy_override", None)

--- a/src/gxassessms/adapters/scubagear/adapter.py
+++ b/src/gxassessms/adapters/scubagear/adapter.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from gxassessms.adapters._base import (
+    check_reserved_args,
     find_latest_output_dir,
     load_json_file,
     parse_extra_args,
@@ -111,19 +112,7 @@ class ScubaGearAdapter:
         if tc.extra_args:
             validated = validate_extra_args(tc.extra_args)
             extra_named, switches = parse_extra_args(validated)
-            _reserved_lower = frozenset(r.lower() for r in _RESERVED_ARGS)
-            reserved_conflicts = {
-                k for k in extra_named if any(r.startswith(k.lower()) for r in _reserved_lower)
-            }
-            reserved_conflicts |= {
-                k for k in switches if any(r.startswith(k.lower()) for r in _reserved_lower)
-            }
-            if reserved_conflicts:
-                raise CollectionError(
-                    f"extra_args contains reserved ScubaGear args that cannot be overridden: "
-                    f"{sorted(reserved_conflicts)}",
-                    adapter_name=self.tool_name,
-                )
+            check_reserved_args(extra_named, switches, _RESERVED_ARGS, self.tool_name)
             named_args.update(extra_named)
 
         if modules:

--- a/src/gxassessms/adapters/scubagear/adapter.py
+++ b/src/gxassessms/adapters/scubagear/adapter.py
@@ -50,6 +50,10 @@ _VALID_PRODUCT_NAMES: frozenset[str] = frozenset(
 _PRODUCT_NAME_MAP: dict[str, str] = {name.lower(): name for name in _VALID_PRODUCT_NAMES}
 _OUTPUT_DIR_PREFIX = "M365BaselineConformance"
 
+# Args the adapter controls -- user cannot override via extra_args.
+# Allowing overrides would redirect ScubaGear output to an attacker-controlled path.
+_RESERVED_ARGS: frozenset[str] = frozenset({"OutPath"})
+
 
 class ScubaGearAdapter:
     """ToolAdapter implementation for ScubaGear (CISA SCuBA baseline assessor for M365)."""
@@ -107,6 +111,19 @@ class ScubaGearAdapter:
         if tc.extra_args:
             validated = validate_extra_args(tc.extra_args)
             extra_named, switches = parse_extra_args(validated)
+            _reserved_lower = frozenset(r.lower() for r in _RESERVED_ARGS)
+            reserved_conflicts = {
+                k for k in extra_named if any(r.startswith(k.lower()) for r in _reserved_lower)
+            }
+            reserved_conflicts |= {
+                k for k in switches if any(r.startswith(k.lower()) for r in _reserved_lower)
+            }
+            if reserved_conflicts:
+                raise CollectionError(
+                    f"extra_args contains reserved ScubaGear args that cannot be overridden: "
+                    f"{sorted(reserved_conflicts)}",
+                    adapter_name=self.tool_name,
+                )
             named_args.update(extra_named)
 
         if modules:

--- a/src/gxassessms/core/contracts/types.py
+++ b/src/gxassessms/core/contracts/types.py
@@ -102,6 +102,7 @@ class ToolAdapter(Protocol):
 @runtime_checkable
 class ReportRenderer(Protocol):
     format: str = ""
+    theme: str = ""
     supported_payload_versions: str = ""
 
     def render(self, payload: ReportPayload, output_dir: Path) -> Path: ...

--- a/src/gxassessms/pipeline/_runner.py
+++ b/src/gxassessms/pipeline/_runner.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from gxassessms.core.config.config import EngagementConfig
 from gxassessms.core.config.datetime_utils import format_utc, utc_now
-from gxassessms.core.contracts.errors import GxAssessError, PipelineError
+from gxassessms.core.contracts.errors import GxAssessError, PipelineError, ReportError
 from gxassessms.core.contracts.types import AdapterRunStatus
 from gxassessms.core.domain.models import (
     AdapterResult,
@@ -202,6 +202,73 @@ def _run_qa_review(
     ctx.qa_results = qa_review(ctx.consolidated_findings, qa_strategy)
 
 
+def _filter_renderers(
+    renderers: list[ReportRenderer],
+    config: EngagementConfig,
+) -> list[ReportRenderer]:
+    """Filter renderers to match config report_formats and report_theme.
+
+    A renderer is selected if:
+    1. Its format is in config.report_formats
+    2. Its theme matches config.report_theme, OR the renderer is
+       theme-agnostic (theme="" or no theme attribute)
+
+    Raises ReportError if no renderers survive filtering (fail-closed).
+    """
+    requested_formats = set(config.report_formats)
+    requested_theme = config.report_theme
+
+    selected: list[ReportRenderer] = []
+    for renderer in renderers:
+        if renderer.format not in requested_formats:
+            continue
+        # getattr required: Protocol defaults are not inherited at runtime.
+        renderer_theme = getattr(renderer, "theme", "")
+        if renderer_theme and renderer_theme != requested_theme:
+            continue
+        selected.append(renderer)
+
+    # Warn for requested formats with no matching renderer
+    selected_formats = {r.format for r in selected}
+    unmatched = sorted(requested_formats - selected_formats)
+    for fmt in unmatched:
+        logger.warning(
+            "No renderer found for requested format '%s' with theme '%s'",
+            fmt,
+            requested_theme,
+        )
+
+    if not selected:
+        raise ReportError(
+            f"No renderers match config: report_formats={config.report_formats}, "
+            f"report_theme={requested_theme!r}. "
+            f"Available: {_describe_renderers(renderers)}"
+        )
+
+    logger.info(
+        "Renderer selection: %d of %d renderers match (formats=%s, theme=%s)",
+        len(selected),
+        len(renderers),
+        config.report_formats,
+        requested_theme,
+    )
+    return selected
+
+
+def _describe_renderers(renderers: list[ReportRenderer]) -> str:
+    """Format available renderers for diagnostic messages."""
+    if not renderers:
+        return "(none discovered)"
+    parts: list[str] = []
+    for r in renderers:
+        theme = getattr(r, "theme", "")
+        label = f"format={r.format}"
+        if theme:
+            label += f",theme={theme}"
+        parts.append(label)
+    return "; ".join(parts)
+
+
 def _run_render(
     ctx: StageContext,
     renderers: list[ReportRenderer],
@@ -213,6 +280,7 @@ def _run_render(
     """Execute RENDER stage: build report payload and render."""
     _require_in_memory("consolidated_findings", ctx.consolidated_findings, Stage.RENDER)
     assert ctx.consolidated_findings is not None  # noqa: S101 -- narrowing for type checker
+    selected_renderers = _filter_renderers(renderers, config)
     if output_dir is None:
         eng_dir = orchestrator._artifact_manager.get_engagement_dir(engagement_id)
         report_dir = eng_dir / "reports"
@@ -226,7 +294,7 @@ def _run_render(
         ctx.consolidated_findings,
         orchestrator._coverage_repo,
     )
-    render(payload, renderers, report_dir)
+    render(payload, selected_renderers, report_dir)
 
 
 def _handle_qa_completion(

--- a/src/gxassessms/reporting/basic_renderer.py
+++ b/src/gxassessms/reporting/basic_renderer.py
@@ -46,6 +46,7 @@ class BasicDocxRenderer:
     """
 
     format: str = "docx"
+    theme: str = "basic"
     supported_payload_versions: str = ">=1.0.0,<2.0.0"
 
     def __init__(self) -> None:

--- a/tests/unit/adapters/test_scubagear_adapter.py
+++ b/tests/unit/adapters/test_scubagear_adapter.py
@@ -1,0 +1,140 @@
+"""Tests for ScubaGearAdapter.collect() reserved-arg guard.
+
+Covers: case-insensitive conflict detection for reserved PowerShell parameters,
+including PowerShell prefix-binding bypasses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gxassessms.core.contracts.errors import CollectionError
+
+
+def _make_config(output_dir: str, extra_args: list[str]):
+    """Build a minimal EngagementConfig with the given extra_args for scubagear."""
+    from gxassessms.core.config.config import AuthConfig, EngagementConfig, ToolConfig
+
+    tc = ToolConfig(enabled=True, output_dir=output_dir, extra_args=extra_args)
+    auth = AuthConfig(method="device_code", tenant_id="t-1", client_id="c-1")
+    return EngagementConfig(
+        client_name="Test",
+        tenant_id="t-1",
+        auth=auth,
+        tools={"scubagear": tc},
+    )
+
+
+class TestReservedArgGuard:
+    """ScubaGearAdapter.collect() must block reserved-arg overrides (case-insensitive).
+
+    Values in test extra_args must satisfy _ARG_PATTERN (no slashes; only word chars, hyphens, dots,
+    commas).
+    The guard must fire before run_verified_powershell is ever called.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _adapter(self) -> None:
+        from gxassessms.adapters.scubagear.adapter import ScubaGearAdapter
+
+        self.adapter = ScubaGearAdapter()
+
+    def _collect_blocked(self, extra_args: list[str]) -> None:
+        """Call collect() and expect a 'reserved' CollectionError."""
+        config = _make_config("/nonexistent/fake-output", extra_args)
+        with patch("gxassessms.core.security.permissions.secure_mkdir"):
+            self.adapter.collect(config, auth=None)
+
+    # -- canonical casing is rejected --
+
+    def test_outpath_canonical_blocked(self) -> None:
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutPath:evil"])
+
+    # -- case variants must also be blocked --
+
+    def test_outpath_lowercase_blocked(self) -> None:
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-outpath:evil"])
+
+    def test_outpath_uppercase_blocked(self) -> None:
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OUTPATH:evil"])
+
+    # -- reserved args as bare switches must also be blocked --
+
+    def test_outpath_as_switch_blocked(self) -> None:
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutPath"])
+
+    def test_outpath_switch_lowercase_blocked(self) -> None:
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-outpath"])
+
+    # -- PowerShell prefix-binding bypasses must be blocked --
+
+    def test_outpath_prefix_named_outpat_blocked(self) -> None:
+        """'-OutPat:foo' is a prefix of 'OutPath' and must be blocked."""
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutPat:foo"])
+
+    def test_outpath_prefix_named_outp_blocked(self) -> None:
+        """'-OutP:foo' is a shorter prefix of 'OutPath' and must be blocked."""
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutP:foo"])
+
+    def test_outpath_prefix_named_out_blocked(self) -> None:
+        """'-Out:foo' is a prefix of 'OutPath' and must be blocked."""
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-Out:foo"])
+
+    def test_outpath_prefix_switch_outpat_blocked(self) -> None:
+        """'-OutPat' as bare switch is a prefix of 'OutPath' and must be blocked."""
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutPat"])
+
+    def test_outpath_prefix_switch_outp_blocked(self) -> None:
+        """'-OutP' as bare switch is a prefix of 'OutPath' and must be blocked."""
+        with pytest.raises(CollectionError, match="reserved"):
+            self._collect_blocked(["-OutP"])
+
+    # -- non-reserved args must pass through --
+
+    def test_non_reserved_arg_passes_guard(self, tmp_path: Path) -> None:
+        """A legitimate extra_arg must not be blocked by the reserved-arg guard.
+
+        run_verified_powershell is mocked so the test never calls PowerShell;
+        we only verify that the reserved-arg check does not raise.
+        """
+        config = _make_config(str(tmp_path), ["-M365Environment:Commercial"])
+        with (
+            patch("gxassessms.core.security.permissions.secure_mkdir"),
+            patch(
+                "gxassessms.adapters._base.run_verified_powershell",
+                side_effect=CollectionError("mocked -- not testing collection"),
+            ),
+            pytest.raises(CollectionError, match="mocked"),
+        ):
+            self.adapter.collect(config, auth=None)
+
+    # -- longer-than-reserved arg must NOT be blocked --
+
+    def test_longer_than_reserved_arg_passes(self, tmp_path: Path) -> None:
+        """'-OutPathExtra:val' is longer than 'OutPath' and must NOT be blocked.
+
+        Tests that the startswith direction is correct: 'outpath'.startswith('outpathextra')
+        is False, so this arg passes the guard.
+        """
+        config = _make_config(str(tmp_path), ["-OutPathExtra:val"])
+        with (
+            patch("gxassessms.core.security.permissions.secure_mkdir"),
+            patch(
+                "gxassessms.adapters._base.run_verified_powershell",
+                side_effect=CollectionError("mocked -- not testing collection"),
+            ),
+            pytest.raises(CollectionError, match="mocked"),
+        ):
+            self.adapter.collect(config, auth=None)

--- a/tests/unit/pipeline/test_orchestrator.py
+++ b/tests/unit/pipeline/test_orchestrator.py
@@ -852,6 +852,7 @@ class TestRunStagesStopStage:
             patch("gxassessms.pipeline._runner._get_stage_output", return_value=[]),
             patch("gxassessms.pipeline._runner._build_report_payload", return_value=MagicMock()),
             patch("gxassessms.pipeline._runner._require_in_memory", return_value=None),
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline.confinement.confine_and_resolve", return_value=[]),
         ):
             run_stages(

--- a/tests/unit/pipeline/test_runner.py
+++ b/tests/unit/pipeline/test_runner.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from gxassessms.core.config.config import AuthConfig, EngagementConfig, ToolConfig
-from gxassessms.core.contracts.errors import PipelineError
+from gxassessms.core.contracts.errors import PipelineError, ReportError
 from gxassessms.core.contracts.types import AdapterRunStatus
 from gxassessms.core.domain.enums import (
     Category,
@@ -38,6 +38,8 @@ from gxassessms.core.domain.models import (
 from gxassessms.pipeline._runner import (
     StageContext,
     _build_report_payload,
+    _describe_renderers,
+    _filter_renderers,
     _get_stage_output,
     _handle_qa_completion,
     _merge_adapter_map,
@@ -417,6 +419,7 @@ class TestRunStagesResumePaths:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=payload,
             ) as mock_build_payload,
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render") as mock_render,
         ):
             run_stages(
@@ -462,6 +465,7 @@ class TestRunStagesResumePaths:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=payload,
             ),
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render") as mock_render,
         ):
             run_stages(
@@ -920,6 +924,7 @@ class TestStageIntegration:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=MagicMock(),
             ),
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render") as mock_render,
         ):
             harness.run(start_stage=Stage.QA_REVIEW, qa_strategy=qa_strategy, output_dir=tmp_path)
@@ -1168,6 +1173,7 @@ class TestRunRender:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=MagicMock(),
             ) as mock_build,
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render") as mock_render,
         ):
             _run_render(ctx, [], tmp_path, _make_config(), "eng-001", harness.orchestrator)
@@ -1187,6 +1193,7 @@ class TestRunRender:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=MagicMock(),
             ) as mock_build,
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render") as mock_render,
         ):
             _run_render(ctx, [], None, _make_config(), "eng-001", harness.orchestrator)
@@ -1203,6 +1210,7 @@ class TestRunRender:
                 "gxassessms.pipeline._runner._build_report_payload",
                 return_value=MagicMock(),
             ) as mock_build,
+            patch("gxassessms.pipeline._runner._filter_renderers", return_value=[]),
             patch("gxassessms.pipeline._runner.render"),
         ):
             _run_render(ctx, [], tmp_path, config, "eng-001", harness.orchestrator)
@@ -1268,3 +1276,170 @@ class TestHandleQaCompletion:
         assert state == EngagementState.QA_REVIEW
         assert should_break is True
         orch._transition_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Renderer filtering tests (Issue #38)
+# ---------------------------------------------------------------------------
+
+
+def _make_renderer(fmt: str = "docx", theme: str = "basic") -> MagicMock:
+    r = MagicMock()
+    r.format = fmt
+    r.theme = theme
+    return r
+
+
+def _make_filter_config(
+    report_formats: list[str] | None = None,
+    report_theme: str = "basic",
+) -> EngagementConfig:
+    """Minimal EngagementConfig for filter tests."""
+    return EngagementConfig(
+        client_name="Test",
+        tenant_id="t-1",
+        auth=AuthConfig(method="device_code", tenant_id="t-1", client_id="c-1"),
+        tools={},
+        report_formats=report_formats or ["docx"],
+        report_theme=report_theme,
+    )
+
+
+class TestFilterRenderers:
+    def test_filters_by_format(self) -> None:
+        docx = _make_renderer("docx", "basic")
+        pptx = _make_renderer("pptx", "basic")
+        config = _make_filter_config(report_formats=["docx"])
+
+        result = _filter_renderers([docx, pptx], config)
+
+        assert result == [docx]
+
+    def test_filters_by_theme(self) -> None:
+        basic = _make_renderer("docx", "basic")
+        gx = _make_renderer("docx", "guardantix")
+        config = _make_filter_config(report_formats=["docx"], report_theme="basic")
+
+        result = _filter_renderers([basic, gx], config)
+
+        assert result == [basic]
+
+    def test_theme_agnostic_via_no_attribute(self) -> None:
+        """Renderer with no theme attribute matches any config theme."""
+        r = MagicMock(spec=["format", "render"])
+        r.format = "docx"
+        config = _make_filter_config(report_formats=["docx"], report_theme="guardantix")
+
+        result = _filter_renderers([r], config)
+
+        assert result == [r]
+
+    def test_theme_agnostic_via_empty_string(self) -> None:
+        """Renderer with theme='' matches any config theme."""
+        r = _make_renderer("docx", "")
+        config = _make_filter_config(report_formats=["docx"], report_theme="guardantix")
+
+        result = _filter_renderers([r], config)
+
+        assert result == [r]
+
+    def test_combined_format_and_theme_filtering(self) -> None:
+        docx_basic = _make_renderer("docx", "basic")
+        docx_gx = _make_renderer("docx", "guardantix")
+        pptx_basic = _make_renderer("pptx", "basic")
+        config = _make_filter_config(report_formats=["docx"], report_theme="basic")
+
+        result = _filter_renderers([docx_basic, docx_gx, pptx_basic], config)
+
+        assert result == [docx_basic]
+
+    def test_multiple_formats_selected(self) -> None:
+        docx = _make_renderer("docx", "basic")
+        pptx = _make_renderer("pptx", "basic")
+        config = _make_filter_config(report_formats=["docx", "pptx"])
+
+        result = _filter_renderers([docx, pptx], config)
+
+        assert result == [docx, pptx]
+
+    def test_raises_report_error_when_no_renderers_match(self) -> None:
+        docx = _make_renderer("docx", "basic")
+        config = _make_filter_config(report_formats=["pdf"])
+
+        with pytest.raises(ReportError, match="No renderers match config"):
+            _filter_renderers([docx], config)
+
+    def test_raises_report_error_when_all_filtered_by_theme(self) -> None:
+        gx = _make_renderer("docx", "guardantix")
+        config = _make_filter_config(report_formats=["docx"], report_theme="basic")
+
+        with pytest.raises(ReportError, match="No renderers match config"):
+            _filter_renderers([gx], config)
+
+    def test_warns_for_unmatched_format(self, caplog: pytest.LogCaptureFixture) -> None:
+        docx = _make_renderer("docx", "basic")
+        config = _make_filter_config(report_formats=["docx", "pptx"])
+
+        with caplog.at_level("WARNING", logger="gxassessms.pipeline._runner"):
+            result = _filter_renderers([docx], config)
+
+        assert result == [docx]
+        assert any("pptx" in record.message for record in caplog.records)
+
+    def test_empty_renderer_list_raises_report_error(self) -> None:
+        config = _make_filter_config(report_formats=["docx"])
+
+        with pytest.raises(ReportError, match="No renderers match config"):
+            _filter_renderers([], config)
+
+    def test_logs_selection_summary(self, caplog: pytest.LogCaptureFixture) -> None:
+        docx = _make_renderer("docx", "basic")
+        pptx = _make_renderer("pptx", "basic")
+        config = _make_filter_config(report_formats=["docx"])
+
+        with caplog.at_level("INFO", logger="gxassessms.pipeline._runner"):
+            _filter_renderers([docx, pptx], config)
+
+        assert any("1 of 2 renderers match" in record.message for record in caplog.records)
+
+
+class TestDescribeRenderers:
+    def test_empty_list(self) -> None:
+        assert _describe_renderers([]) == "(none discovered)"
+
+    def test_with_theme(self) -> None:
+        r = _make_renderer("docx", "basic")
+        assert _describe_renderers([r]) == "format=docx,theme=basic"
+
+    def test_without_theme(self) -> None:
+        r = _make_renderer("docx", "")
+        assert _describe_renderers([r]) == "format=docx"
+
+    def test_multiple(self) -> None:
+        r1 = _make_renderer("docx", "basic")
+        r2 = _make_renderer("pptx", "guardantix")
+        result = _describe_renderers([r1, r2])
+        assert result == "format=docx,theme=basic; format=pptx,theme=guardantix"
+
+
+class TestRunRenderFilterIntegration:
+    def test_run_render_passes_only_filtered_renderers(
+        self, harness: RunnerHarness, tmp_path: Path
+    ) -> None:
+        """_run_render() must filter renderers before passing to render()."""
+        docx = _make_renderer("docx", "basic")
+        pptx = _make_renderer("pptx", "basic")
+        config = _make_filter_config(report_formats=["docx"])
+        ctx = StageContext(consolidated_findings=[_make_consolidated()])
+
+        with (
+            patch(
+                "gxassessms.pipeline._runner._build_report_payload",
+                return_value=MagicMock(),
+            ) as mock_build,
+            patch("gxassessms.pipeline._runner.render") as mock_render,
+        ):
+            _run_render(ctx, [docx, pptx], tmp_path, config, "eng-001", harness.orchestrator)
+
+        # render() should receive only the docx renderer, not both
+        mock_render.assert_called_once_with(mock_build.return_value, [docx], tmp_path)


### PR DESCRIPTION
## Summary

- **Issue #58 (bug):** ScubaGear adapter had no reserved-arg guard for `OutPath` -- a misconfigured or adversarial `extra_args` entry could redirect output to an attacker-controlled path. Added prefix-aware guard matching the Monkey365 pattern, then extracted the shared logic into `check_reserved_args()` in `_base.py` to eliminate duplication across both adapters.
- **Issue #38 (enhancement):** The render stage executed ALL discovered renderers regardless of the operator's `report_formats` and `report_theme` config, expanding the trusted execution surface. Added `_filter_renderers()` to `_run_render()` -- only renderers matching config are passed to `render()`. Fail-closed with `ReportError` if no renderers survive filtering. Added `theme` attribute to `ReportRenderer` Protocol and `BasicDocxRenderer`.

## Changes

### Issue #58
- `src/gxassessms/adapters/scubagear/adapter.py` -- `_RESERVED_ARGS` constant + guard call
- `src/gxassessms/adapters/_base.py` -- new `check_reserved_args()` shared helper
- `src/gxassessms/adapters/monkey365/adapter.py` -- refactored to use shared helper
- `tests/unit/adapters/test_scubagear_adapter.py` -- 12 tests (canonical, case variants, switches, prefix-binding, pass-through, longer-than-reserved)

### Issue #38
- `src/gxassessms/core/contracts/types.py` -- `theme: str = ""` on `ReportRenderer` Protocol
- `src/gxassessms/reporting/basic_renderer.py` -- `theme: str = "basic"` on `BasicDocxRenderer`
- `src/gxassessms/pipeline/_runner.py` -- `_filter_renderers()`, `_describe_renderers()`, wired into `_run_render()`
- `tests/unit/pipeline/test_runner.py` -- 16 new tests + 5 existing tests updated

## Test plan

- [ ] `pytest tests/unit/adapters/test_scubagear_adapter.py -v` -- 12 reserved-arg guard tests pass
- [ ] `pytest tests/unit/adapters/test_monkey365_adapter.py -v` -- existing Monkey365 guard tests still pass after shared helper extraction
- [ ] `pytest tests/unit/pipeline/test_runner.py -v -k "FilterRenderer or DescribeRenderer or RunRenderFilter"` -- 16 renderer filtering tests pass
- [ ] `pytest tests/ --no-cov` -- full suite: 2291 passed, 3 skipped, 0 failures

Closes #58
Closes #38