### PR TITLE
feat: add flags field to Narratives TypedDict for budget/completion signaling

### DIFF
--- a/src/gxassessms/core/contracts/types.py
+++ b/src/gxassessms/core/contracts/types.py
@@ -9,7 +9,7 @@ by mypy).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, TypedDict, runtime_checkable
+from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict, runtime_checkable
 
 from gxassessms.core.domain.constants import AdapterCapability
 from gxassessms.core.domain.enums import (  # noqa: F401 (re-exported)
@@ -54,6 +54,7 @@ class Narratives(TypedDict):
     executive_summary: str
     roadmap: str
     findings_narrative: str | None
+    flags: NotRequired[list[str]]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -47,9 +47,6 @@ class TestTypeAliases:
         assert "executive_summary" in annotations
         assert "roadmap" in annotations
         assert "findings_narrative" in annotations
-
-    def test_narratives_flags_field_exists(self) -> None:
-        annotations = Narratives.__annotations__
         assert "flags" in annotations
 
     def test_narratives_without_flags_is_valid(self) -> None:
@@ -58,7 +55,6 @@ class TestTypeAliases:
             "roadmap": "roadmap text",
             "findings_narrative": None,
         }
-        assert n["executive_summary"] == "summary"
         assert "flags" not in n
 
     def test_narratives_with_flags_is_valid(self) -> None:

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -48,6 +48,28 @@ class TestTypeAliases:
         assert "roadmap" in annotations
         assert "findings_narrative" in annotations
 
+    def test_narratives_flags_field_exists(self) -> None:
+        annotations = Narratives.__annotations__
+        assert "flags" in annotations
+
+    def test_narratives_without_flags_is_valid(self) -> None:
+        n: Narratives = {
+            "executive_summary": "summary",
+            "roadmap": "roadmap text",
+            "findings_narrative": None,
+        }
+        assert n["executive_summary"] == "summary"
+        assert "flags" not in n
+
+    def test_narratives_with_flags_is_valid(self) -> None:
+        n: Narratives = {
+            "executive_summary": "summary",
+            "roadmap": "roadmap text",
+            "findings_narrative": None,
+            "flags": ["budget_exhausted"],
+        }
+        assert n["flags"] == ["budget_exhausted"]
+
 
 class TestPrerequisiteResult:
     def test_prerequisite_result_is_typed_dict(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `flags: NotRequired[list[str]]` to `Narratives` TypedDict, consistent with the `flags` field already on `QAResult`
- Imports `NotRequired` from `typing` in `core/contracts/types.py`
- Backward-compatible: existing code constructing `Narratives` without `flags` continues to work unchanged

Closes #70

## Test plan

- [ ] `test_narratives_flags_field_exists` — confirms `flags` is in TypedDict annotations
- [ ] `test_narratives_without_flags_is_valid` — backward compat: construction without `flags` works
- [ ] `test_narratives_with_flags_is_valid` — forward path: construction with `flags` list works
- [ ] Full suite: 2294 passed, 3 skipped