### PR TITLE
feat: pass EngagementConfig to QA strategy plugins at construction

### DIFF
--- a/src/gxassessms/cli/_helpers.py
+++ b/src/gxassessms/cli/_helpers.py
@@ -7,6 +7,7 @@ each other.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_QA_STRATEGY_GROUP = "gxassessms.qa_strategies"
+QA_STRATEGY_GROUP = "gxassessms.qa_strategies"
 
 
 def _instantiate_plugin(
@@ -29,22 +30,30 @@ def _instantiate_plugin(
 ) -> Any | None:
     """Instantiate a plugin class, optionally passing engagement config kwargs.
 
-    Tries ``cls(**kwargs)`` first when kwargs are provided; falls back to
-    ``cls()`` on TypeError (zero-arg constructor). Any other instantiation
-    failure is logged as a warning and returns None.
+    When *kwargs* are provided the constructor signature is probed via
+    ``inspect.signature`` first.  If the signature accepts the kwargs the
+    plugin is called with them; any failure (including ``TypeError``) is
+    treated as a real error and the plugin is skipped.  If the signature does
+    not accept the kwargs the call falls back silently to the zero-argument
+    constructor.  Any failure from the zero-argument path is also logged as a
+    warning and returns ``None``.
     """
+    if kwargs:
+        try:
+            inspect.signature(cls).bind(**kwargs)
+        except TypeError:
+            # Signature mismatch -- constructor does not accept these kwargs.
+            logger.debug(
+                "%s plugin %s does not accept engagement config kwargs; using no-arg constructor",
+                group,
+                name,
+            )
+            kwargs = {}
+        except ValueError:
+            # inspect.signature could not introspect cls; proceed with kwargs.
+            pass
     try:
-        if kwargs:
-            try:
-                return cls(**kwargs)
-            except TypeError:
-                logger.debug(
-                    "%s plugin %s does not accept engagement config kwargs; "
-                    "retrying with no-arg constructor",
-                    group,
-                    name,
-                )
-        return cls()
+        return cls(**kwargs) if kwargs else cls()
     except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
         logger.warning("Failed to instantiate %s plugin %s: %s", group, name, exc)
         return None
@@ -258,7 +267,7 @@ def discover_plugin(
         )
 
     kwargs: dict[str, Any] = {}
-    if config is not None and group == _QA_STRATEGY_GROUP:
+    if config is not None and group == QA_STRATEGY_GROUP:
         kwargs = {
             "model": config.qa_model,
             "token_budget": config.qa_token_budget,

--- a/src/gxassessms/cli/_helpers.py
+++ b/src/gxassessms/cli/_helpers.py
@@ -18,6 +18,37 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_QA_STRATEGY_GROUP = "gxassessms.qa_strategies"
+
+
+def _instantiate_plugin(
+    cls: Any,
+    name: str,
+    group: str,
+    kwargs: dict[str, Any],
+) -> Any | None:
+    """Instantiate a plugin class, optionally passing engagement config kwargs.
+
+    Tries ``cls(**kwargs)`` first when kwargs are provided; falls back to
+    ``cls()`` on TypeError (zero-arg constructor). Any other instantiation
+    failure is logged as a warning and returns None.
+    """
+    try:
+        if kwargs:
+            try:
+                return cls(**kwargs)
+            except TypeError:
+                logger.debug(
+                    "%s plugin %s does not accept engagement config kwargs; "
+                    "retrying with no-arg constructor",
+                    group,
+                    name,
+                )
+        return cls()
+    except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
+        logger.warning("Failed to instantiate %s plugin %s: %s", group, name, exc)
+        return None
+
 
 def build_orchestrator() -> Any:
     """Build an Orchestrator with all dependencies.
@@ -227,7 +258,7 @@ def discover_plugin(
         )
 
     kwargs: dict[str, Any] = {}
-    if config is not None and group == "gxassessms.qa_strategies":
+    if config is not None and group == _QA_STRATEGY_GROUP:
         kwargs = {
             "model": config.qa_model,
             "token_budget": config.qa_token_budget,
@@ -244,21 +275,7 @@ def discover_plugin(
                 result.names,
             )
             return None
-        try:
-            if kwargs:
-                try:
-                    return cls(**kwargs)
-                except TypeError:
-                    logger.debug(
-                        "%s plugin %s does not accept engagement config kwargs; "
-                        "retrying with no-arg constructor",
-                        group,
-                        name,
-                    )
-            return cls()
-        except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
-            logger.warning("Failed to instantiate %s plugin %s: %s", group, name, exc)
-            return None
+        return _instantiate_plugin(cls, name, group, kwargs)
 
     if not result.names:
         return None
@@ -274,25 +291,9 @@ def discover_plugin(
     for candidate_name in sorted_names:
         cls = result.get(candidate_name)
         if cls is not None:
-            try:
-                if kwargs:
-                    try:
-                        return cls(**kwargs)
-                    except TypeError:
-                        logger.debug(
-                            "%s plugin %s does not accept engagement config kwargs; "
-                            "retrying with no-arg constructor",
-                            group,
-                            candidate_name,
-                        )
-                return cls()
-            except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
-                logger.warning(
-                    "Failed to instantiate %s plugin %s: %s",
-                    group,
-                    candidate_name,
-                    exc,
-                )
+            inst = _instantiate_plugin(cls, candidate_name, group, kwargs)
+            if inst is not None:
+                return inst
     return None
 
 

--- a/src/gxassessms/cli/_helpers.py
+++ b/src/gxassessms/cli/_helpers.py
@@ -67,8 +67,9 @@ def _instantiate_plugin(
                 list(kwargs),
             )
         except ValueError:
-            # inspect.signature could not introspect cls; proceed with kwargs.
-            pass
+            # inspect.signature could not introspect cls (e.g. C extensions,
+            # dynamic callables); fall back to zero-arg construction.
+            kwargs = {}
     try:
         return cls(**kwargs) if kwargs else cls()
     except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:

--- a/src/gxassessms/cli/_helpers.py
+++ b/src/gxassessms/cli/_helpers.py
@@ -31,24 +31,41 @@ def _instantiate_plugin(
     """Instantiate a plugin class, optionally passing engagement config kwargs.
 
     When *kwargs* are provided the constructor signature is probed via
-    ``inspect.signature`` first.  If the signature accepts the kwargs the
-    plugin is called with them; any failure (including ``TypeError``) is
-    treated as a real error and the plugin is skipped.  If the signature does
-    not accept the kwargs the call falls back silently to the zero-argument
-    constructor.  Any failure from the zero-argument path is also logged as a
-    warning and returns ``None``.
+    ``inspect.signature`` first.  If the signature accepts all kwargs the
+    plugin is called with them; any failure from that call (including
+    ``TypeError``) is treated as a real error and the plugin is skipped.
+    If the signature accepts only a subset of the kwargs, the plugin is
+    called with the accepted subset.  If the signature accepts none of the
+    kwargs (or the signature cannot be determined), the call falls back to
+    the zero-argument constructor.  Any failure from either path is logged
+    as a warning and returns ``None``.
     """
     if kwargs:
+        sig: inspect.Signature | None = None
         try:
-            inspect.signature(cls).bind(**kwargs)
+            sig = inspect.signature(cls)
+            sig.bind(**kwargs)
         except TypeError:
-            # Signature mismatch -- constructor does not accept these kwargs.
+            if sig is not None:
+                # Filter to only the kwargs the constructor explicitly accepts.
+                has_var_keyword = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+                )
+                if not has_var_keyword:
+                    kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters}
+                # If has_var_keyword: constructor accepts **kwargs but bind still
+                # failed (e.g. missing required positional arg) -- keep original
+                # kwargs and let the outer try handle it.
+            else:
+                # inspect.signature(cls) raised TypeError -- cls is not callable.
+                kwargs = {}
             logger.debug(
-                "%s plugin %s does not accept engagement config kwargs; using no-arg constructor",
+                "%s plugin %s does not accept all engagement config kwargs; "
+                "using filtered kwargs: %s",
                 group,
                 name,
+                list(kwargs),
             )
-            kwargs = {}
         except ValueError:
             # inspect.signature could not introspect cls; proceed with kwargs.
             pass

--- a/src/gxassessms/cli/_helpers.py
+++ b/src/gxassessms/cli/_helpers.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from gxassessms.core.contracts.errors import GxAssessError
+
+if TYPE_CHECKING:
+    from gxassessms.core.config.config import EngagementConfig
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +193,12 @@ def discover_adapter_metadata() -> list[dict[str, Any]]:
     return result
 
 
-def discover_plugin(group: str, *, name: str | None = None) -> Any | None:
+def discover_plugin(
+    group: str,
+    *,
+    name: str | None = None,
+    config: EngagementConfig | None = None,
+) -> Any | None:
     """Discover and instantiate a plugin from an entry point group.
 
     Selection logic:
@@ -198,8 +206,14 @@ def discover_plugin(group: str, *, name: str | None = None) -> Any | None:
     2. Otherwise, plugins are sorted by optional ``priority`` class
        attribute (descending, default 0). Ties broken by discovery order.
 
-    Returns an instance, or None if nothing found. Used for singleton
-    plugins like normalization policy or QA strategy.
+    When *config* is provided and *group* is ``gxassessms.qa_strategies``,
+    the plugin is constructed with ``model``, ``token_budget``, and
+    ``client_name`` keyword arguments drawn from the config. If the plugin
+    raises ``TypeError`` (zero-arg constructor), the call is retried with
+    no arguments. Any other exception from the kwargs call is treated as
+    an instantiation failure (logged, plugin skipped).
+
+    Returns an instance, or None if nothing found.
     """
     from gxassessms.registry import discover_entry_points
 
@@ -212,6 +226,14 @@ def discover_plugin(group: str, *, name: str | None = None) -> Any | None:
             err.message,
         )
 
+    kwargs: dict[str, Any] = {}
+    if config is not None and group == "gxassessms.qa_strategies":
+        kwargs = {
+            "model": config.qa_model,
+            "token_budget": config.qa_token_budget,
+            "client_name": config.client_name,
+        }
+
     if name is not None:
         cls = result.get(name)
         if cls is None:
@@ -223,6 +245,16 @@ def discover_plugin(group: str, *, name: str | None = None) -> Any | None:
             )
             return None
         try:
+            if kwargs:
+                try:
+                    return cls(**kwargs)
+                except TypeError:
+                    logger.debug(
+                        "%s plugin %s does not accept engagement config kwargs; "
+                        "retrying with no-arg constructor",
+                        group,
+                        name,
+                    )
             return cls()
         except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
             logger.warning("Failed to instantiate %s plugin %s: %s", group, name, exc)
@@ -243,6 +275,16 @@ def discover_plugin(group: str, *, name: str | None = None) -> Any | None:
         cls = result.get(candidate_name)
         if cls is not None:
             try:
+                if kwargs:
+                    try:
+                        return cls(**kwargs)
+                    except TypeError:
+                        logger.debug(
+                            "%s plugin %s does not accept engagement config kwargs; "
+                            "retrying with no-arg constructor",
+                            group,
+                            candidate_name,
+                        )
                 return cls()
             except (TypeError, ValueError, RuntimeError, FileNotFoundError) as exc:
                 logger.warning(

--- a/src/gxassessms/cli/commands/consolidate.py
+++ b/src/gxassessms/cli/commands/consolidate.py
@@ -89,7 +89,9 @@ def consolidate_cmd(
             f"from stage {start_stage.value}...[/bold]"
         )
 
-        qa_strategy = _helpers.discover_plugin("gxassessms.qa_strategies", name=qa_strategy_name)
+        qa_strategy = _helpers.discover_plugin(
+            "gxassessms.qa_strategies", name=qa_strategy_name, config=config
+        )
         if qa_strategy_name is not None and qa_strategy is None:
             raise click.BadParameter(
                 f"QA strategy {qa_strategy_name!r} not found.",

--- a/src/gxassessms/cli/commands/consolidate.py
+++ b/src/gxassessms/cli/commands/consolidate.py
@@ -90,7 +90,7 @@ def consolidate_cmd(
         )
 
         qa_strategy = _helpers.discover_plugin(
-            "gxassessms.qa_strategies", name=qa_strategy_name, config=config
+            _helpers.QA_STRATEGY_GROUP, name=qa_strategy_name, config=config
         )
         if qa_strategy_name is not None and qa_strategy is None:
             raise click.BadParameter(

--- a/src/gxassessms/cli/commands/replay.py
+++ b/src/gxassessms/cli/commands/replay.py
@@ -98,7 +98,7 @@ def replay_cmd(engagement_id: str, from_stage: str, qa_strategy_name: str | None
         )
 
         qa_strategy = _helpers.discover_plugin(
-            "gxassessms.qa_strategies", name=qa_strategy_name, config=config
+            _helpers.QA_STRATEGY_GROUP, name=qa_strategy_name, config=config
         )
         if qa_strategy_name is not None and qa_strategy is None:
             raise click.BadParameter(

--- a/src/gxassessms/cli/commands/replay.py
+++ b/src/gxassessms/cli/commands/replay.py
@@ -97,7 +97,9 @@ def replay_cmd(engagement_id: str, from_stage: str, qa_strategy_name: str | None
             f"[bold]Replaying engagement {engagement_id} from {start_stage.value}...[/bold]"
         )
 
-        qa_strategy = _helpers.discover_plugin("gxassessms.qa_strategies", name=qa_strategy_name)
+        qa_strategy = _helpers.discover_plugin(
+            "gxassessms.qa_strategies", name=qa_strategy_name, config=config
+        )
         if qa_strategy_name is not None and qa_strategy is None:
             raise click.BadParameter(
                 f"QA strategy {qa_strategy_name!r} not found.",

--- a/src/gxassessms/cli/commands/run.py
+++ b/src/gxassessms/cli/commands/run.py
@@ -165,7 +165,7 @@ def run_cmd(
             "normalization_policy": _helpers.build_normalization_policy(),
             "consolidation_rule": _helpers.build_consolidation_rule(),
             "qa_strategy": _helpers.discover_plugin(
-                "gxassessms.qa_strategies", name=qa_strategy_name, config=config
+                _helpers.QA_STRATEGY_GROUP, name=qa_strategy_name, config=config
             ),
             "renderers": _helpers.discover_all_plugins("gxassessms.renderers"),
         }

--- a/src/gxassessms/cli/commands/run.py
+++ b/src/gxassessms/cli/commands/run.py
@@ -165,7 +165,7 @@ def run_cmd(
             "normalization_policy": _helpers.build_normalization_policy(),
             "consolidation_rule": _helpers.build_consolidation_rule(),
             "qa_strategy": _helpers.discover_plugin(
-                "gxassessms.qa_strategies", name=qa_strategy_name
+                "gxassessms.qa_strategies", name=qa_strategy_name, config=config
             ),
             "renderers": _helpers.discover_all_plugins("gxassessms.renderers"),
         }

--- a/src/gxassessms/qa/noop.py
+++ b/src/gxassessms/qa/noop.py
@@ -24,12 +24,10 @@ class NoOpQAStrategy:
     is_noop: bool = True
     priority: int = 0
 
-    def __init__(
-        self,
-        model: str = "claude-sonnet-4-6",
-        token_budget: int = 100000,
-        client_name: str = "the client",
-    ) -> None:
+    def __init__(self, **_kwargs: object) -> None:
+        # Accepts and ignores engagement config kwargs (model, token_budget,
+        # client_name) so discover_plugin can construct all QA strategies
+        # uniformly without special-casing the no-op.
         pass
 
     def review_findings(self, findings: list[ConsolidatedFinding]) -> list[QAResult]:

--- a/src/gxassessms/qa/noop.py
+++ b/src/gxassessms/qa/noop.py
@@ -24,6 +24,14 @@ class NoOpQAStrategy:
     is_noop: bool = True
     priority: int = 0
 
+    def __init__(
+        self,
+        model: str = "claude-sonnet-4-6",
+        token_budget: int = 100000,
+        client_name: str = "the client",
+    ) -> None:
+        pass
+
     def review_findings(self, findings: list[ConsolidatedFinding]) -> list[QAResult]:
         """Return empty list -- no findings are reviewed."""
         return []

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -15,6 +15,7 @@ Return value shapes:
 
 from __future__ import annotations
 
+import inspect
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -414,6 +415,32 @@ class TestDiscoverPlugin:
             result = discover_plugin(QA_STRATEGY_GROUP, name="legacy_qa", config=config)
 
         assert isinstance(result, _LegacyQAPlugin)
+
+    def test_config_kwargs_fallback_to_zero_arg_when_signature_unintrospectable(self):
+        """When inspect.signature raises ValueError (e.g. C extensions), fall back to cls()."""
+
+        class _CExtLikeQAPlugin:
+            pass
+
+        real_signature = inspect.signature
+
+        def _patched_signature(obj, **kw):
+            if obj is _CExtLikeQAPlugin:
+                raise ValueError("no signature found")
+            return real_signature(obj, **kw)
+
+        disc_result = _make_result(plugins={"cext_qa": _CExtLikeQAPlugin})
+        config = _make_config()
+
+        with (
+            patch("gxassessms.registry.discover_entry_points", return_value=disc_result),
+            patch("gxassessms.cli._helpers.inspect.signature", side_effect=_patched_signature),
+        ):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
+
+        assert isinstance(result, _CExtLikeQAPlugin)
 
     def test_typeerror_inside_constructor_is_not_retried(self, caplog):
         """TypeError from inside the constructor body is treated as a real failure, not retried."""

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -343,6 +343,46 @@ class TestDiscoverPlugin:
             client_name=config.client_name,
         )
 
+    def test_config_kwargs_partial_subset_loop_path(self):
+        """Loop path: plugin accepts model+token_budget but not client_name -> subset used."""
+
+        class _PartialQAPlugin:
+            def __init__(self, model: str, token_budget: int) -> None:
+                self.model = model
+                self.token_budget = token_budget
+
+        disc_result = _make_result(plugins={"partial_qa": _PartialQAPlugin})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
+
+        assert isinstance(result, _PartialQAPlugin)
+        assert result.model == config.qa_model
+        assert result.token_budget == config.qa_token_budget
+
+    def test_config_kwargs_partial_subset_named_path(self):
+        """Named path: plugin accepts model+token_budget but not client_name -> subset used."""
+
+        class _PartialQAPlugin:
+            def __init__(self, model: str, token_budget: int) -> None:
+                self.model = model
+                self.token_budget = token_budget
+
+        disc_result = _make_result(plugins={"partial_qa": _PartialQAPlugin})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin(QA_STRATEGY_GROUP, name="partial_qa", config=config)
+
+        assert isinstance(result, _PartialQAPlugin)
+        assert result.model == config.qa_model
+        assert result.token_budget == config.qa_token_budget
+
     def test_config_kwargs_fallback_to_zero_arg_when_signature_mismatch_loop(self):
         """Loop path: plugin with zero-arg constructor -> signature probed, falls back to cls()."""
 

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gxassessms.adapters import AdapterRegistry
+from gxassessms.cli._helpers import QA_STRATEGY_GROUP
 from gxassessms.core.config.config import AuthConfig, EngagementConfig
 from gxassessms.registry import DiscoveryError, DiscoveryResult
 
@@ -314,7 +315,7 @@ class TestDiscoverPlugin:
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", config=config)
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
 
         assert result is mock_instance
         MockCls.assert_called_once_with(
@@ -333,7 +334,7 @@ class TestDiscoverPlugin:
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", name="gx_qa", config=config)
+            result = discover_plugin(QA_STRATEGY_GROUP, name="gx_qa", config=config)
 
         assert result is mock_instance
         MockCls.assert_called_once_with(
@@ -342,47 +343,58 @@ class TestDiscoverPlugin:
             client_name=config.client_name,
         )
 
-    def test_config_kwargs_fallback_to_zero_arg_on_typeerror_loop(self):
-        """Loop path: TypeError from kwargs call -> retried with no-arg, success."""
-        mock_instance = MagicMock(name="fallback_inst")
+    def test_config_kwargs_fallback_to_zero_arg_when_signature_mismatch_loop(self):
+        """Loop path: plugin with zero-arg constructor -> signature probed, falls back to cls()."""
 
-        def side_effect(*args, **kwargs):
-            if kwargs:
-                raise TypeError("unexpected keyword argument 'model'")
-            return mock_instance
+        class _LegacyQAPlugin:
+            """Simulates a legacy plugin that only accepts a zero-arg constructor."""
 
-        MockCls = MagicMock(side_effect=side_effect)
-        disc_result = _make_result(plugins={"legacy_qa": MockCls})
+        disc_result = _make_result(plugins={"legacy_qa": _LegacyQAPlugin})
         config = _make_config()
 
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", config=config)
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
 
-        assert result is mock_instance
-        assert MockCls.call_count == 2  # kwargs attempt + no-arg fallback
+        assert isinstance(result, _LegacyQAPlugin)
 
-    def test_config_kwargs_fallback_to_zero_arg_on_typeerror_named(self):
-        """Named path: TypeError from kwargs call -> retried with no-arg, success."""
-        mock_instance = MagicMock(name="fallback_inst")
+    def test_config_kwargs_fallback_to_zero_arg_when_signature_mismatch_named(self):
+        """Named path: plugin with zero-arg constructor -> signature probed, falls back to cls()."""
 
-        def side_effect(*args, **kwargs):
-            if kwargs:
-                raise TypeError("unexpected keyword argument 'model'")
-            return mock_instance
+        class _LegacyQAPlugin:
+            """Simulates a legacy plugin that only accepts a zero-arg constructor."""
 
-        MockCls = MagicMock(side_effect=side_effect)
-        disc_result = _make_result(plugins={"legacy_qa": MockCls})
+        disc_result = _make_result(plugins={"legacy_qa": _LegacyQAPlugin})
         config = _make_config()
 
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", name="legacy_qa", config=config)
+            result = discover_plugin(QA_STRATEGY_GROUP, name="legacy_qa", config=config)
 
-        assert result is mock_instance
-        assert MockCls.call_count == 2
+        assert isinstance(result, _LegacyQAPlugin)
+
+    def test_typeerror_inside_constructor_is_not_retried(self, caplog):
+        """TypeError from inside the constructor body is treated as a real failure, not retried."""
+
+        class _BadQAPlugin:
+            def __init__(self, model: str, token_budget: int, client_name: str) -> None:
+                raise TypeError("unsupported model type")
+
+        disc_result = _make_result(plugins={"bad_qa": _BadQAPlugin})
+        config = _make_config()
+
+        with (
+            patch("gxassessms.registry.discover_entry_points", return_value=disc_result),
+            caplog.at_level(logging.WARNING, logger="gxassessms.cli._helpers"),
+        ):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
+
+        assert result is None
+        assert any("bad_qa" in r.message for r in caplog.records)
 
     def test_non_typeerror_from_kwargs_is_not_swallowed(self, caplog):
         """ValueError from kwargs call is NOT silently swallowed -- plugin is skipped."""
@@ -396,7 +408,7 @@ class TestDiscoverPlugin:
         ):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", config=config)
+            result = discover_plugin(QA_STRATEGY_GROUP, config=config)
 
         assert result is None
         assert any("bad_qa" in r.message for r in caplog.records)
@@ -426,7 +438,7 @@ class TestDiscoverPlugin:
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             from gxassessms.cli._helpers import discover_plugin
 
-            result = discover_plugin("gxassessms.qa_strategies", config=None)
+            result = discover_plugin(QA_STRATEGY_GROUP, config=None)
 
         assert result is mock_instance
         MockCls.assert_called_once_with()

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gxassessms.adapters import AdapterRegistry
+from gxassessms.core.config.config import AuthConfig, EngagementConfig
 from gxassessms.registry import DiscoveryError, DiscoveryResult
 
 # ---------------------------------------------------------------------------
@@ -46,6 +47,28 @@ def _make_result(plugins: dict, errors: list | None = None) -> DiscoveryResult:
 
 def _make_error(name: str = "bad_plugin", msg: str = "some error") -> DiscoveryError:
     return DiscoveryError(plugin_name=name, error_type="ValidationError", message=msg)
+
+
+def _make_config(
+    *,
+    qa_model: str = "claude-opus-4-6",
+    qa_token_budget: int = 50000,
+    client_name: str = "Acme Corp",
+) -> EngagementConfig:
+    """Build a minimal EngagementConfig for tests."""
+    return EngagementConfig(
+        client_name=client_name,
+        tenant_id="00000000-0000-0000-0000-000000000001",
+        auth=AuthConfig(
+            method="client_credential",
+            tenant_id="00000000-0000-0000-0000-000000000001",
+            client_id="00000000-0000-0000-0000-000000000002",
+            client_secret_env="GX_SECRET",  # pragma: allowlist secret
+        ),
+        tools={},
+        qa_model=qa_model,
+        qa_token_budget=qa_token_budget,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +303,133 @@ class TestDiscoverPlugin:
         with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
             result = discover_plugin("some.group")
         assert result is inst
+
+    def test_config_kwargs_passed_to_qa_strategy_loop_path(self):
+        """Loop path: config provided for qa_strategies group -> cls called with kwargs."""
+        mock_instance = MagicMock(name="qa_inst")
+        MockCls = MagicMock(return_value=mock_instance)
+        disc_result = _make_result(plugins={"gx_qa": MockCls})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", config=config)
+
+        assert result is mock_instance
+        MockCls.assert_called_once_with(
+            model=config.qa_model,
+            token_budget=config.qa_token_budget,
+            client_name=config.client_name,
+        )
+
+    def test_config_kwargs_passed_to_qa_strategy_named_path(self):
+        """Named path: config provided for qa_strategies group -> cls called with kwargs."""
+        mock_instance = MagicMock(name="qa_inst")
+        MockCls = MagicMock(return_value=mock_instance)
+        disc_result = _make_result(plugins={"gx_qa": MockCls})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", name="gx_qa", config=config)
+
+        assert result is mock_instance
+        MockCls.assert_called_once_with(
+            model=config.qa_model,
+            token_budget=config.qa_token_budget,
+            client_name=config.client_name,
+        )
+
+    def test_config_kwargs_fallback_to_zero_arg_on_typeerror_loop(self):
+        """Loop path: TypeError from kwargs call -> retried with no-arg, success."""
+        mock_instance = MagicMock(name="fallback_inst")
+
+        def side_effect(*args, **kwargs):
+            if kwargs:
+                raise TypeError("unexpected keyword argument 'model'")
+            return mock_instance
+
+        MockCls = MagicMock(side_effect=side_effect)
+        disc_result = _make_result(plugins={"legacy_qa": MockCls})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", config=config)
+
+        assert result is mock_instance
+        assert MockCls.call_count == 2  # kwargs attempt + no-arg fallback
+
+    def test_config_kwargs_fallback_to_zero_arg_on_typeerror_named(self):
+        """Named path: TypeError from kwargs call -> retried with no-arg, success."""
+        mock_instance = MagicMock(name="fallback_inst")
+
+        def side_effect(*args, **kwargs):
+            if kwargs:
+                raise TypeError("unexpected keyword argument 'model'")
+            return mock_instance
+
+        MockCls = MagicMock(side_effect=side_effect)
+        disc_result = _make_result(plugins={"legacy_qa": MockCls})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", name="legacy_qa", config=config)
+
+        assert result is mock_instance
+        assert MockCls.call_count == 2
+
+    def test_non_typeerror_from_kwargs_is_not_swallowed(self, caplog):
+        """ValueError from kwargs call is NOT silently swallowed -- plugin is skipped."""
+        MockCls = MagicMock(side_effect=ValueError("bad model name"))
+        disc_result = _make_result(plugins={"bad_qa": MockCls})
+        config = _make_config()
+
+        with (
+            patch("gxassessms.registry.discover_entry_points", return_value=disc_result),
+            caplog.at_level(logging.WARNING, logger="gxassessms.cli._helpers"),
+        ):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", config=config)
+
+        assert result is None
+        assert any("bad_qa" in r.message for r in caplog.records)
+        MockCls.assert_called_once()  # called with kwargs, not retried
+
+    def test_config_not_applied_for_non_qa_group(self):
+        """Config provided but group is not qa_strategies -> cls() called with no kwargs."""
+        mock_instance = MagicMock(name="adapter_inst")
+        MockCls = MagicMock(return_value=mock_instance)
+        disc_result = _make_result(plugins={"my_adapter": MockCls})
+        config = _make_config()
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.adapters", config=config)
+
+        assert result is mock_instance
+        MockCls.assert_called_once_with()  # no kwargs
+
+    def test_none_config_uses_zero_arg_for_qa_group(self):
+        """config=None for qa_strategies -> cls() called with no kwargs."""
+        mock_instance = MagicMock(name="qa_inst")
+        MockCls = MagicMock(return_value=mock_instance)
+        disc_result = _make_result(plugins={"noop": MockCls})
+
+        with patch("gxassessms.registry.discover_entry_points", return_value=disc_result):
+            from gxassessms.cli._helpers import discover_plugin
+
+            result = discover_plugin("gxassessms.qa_strategies", config=None)
+
+        assert result is mock_instance
+        MockCls.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/qa/test_noop.py
+++ b/tests/unit/qa/test_noop.py
@@ -101,3 +101,19 @@ class TestNoOpIsNoOp:
         """The orchestrator checks this attribute to decide auto-advance."""
         strategy = NoOpQAStrategy()
         assert strategy.is_noop is True
+
+
+class TestNoOpConstructor:
+    def test_accepts_engagement_config_kwargs(self) -> None:
+        """NoOpQAStrategy accepts model/token_budget/client_name without raising."""
+        strategy = NoOpQAStrategy(
+            model="claude-opus-4-6",
+            token_budget=50000,
+            client_name="Acme Corp",
+        )
+        assert strategy.is_noop is True
+
+    def test_zero_arg_construction_still_works(self) -> None:
+        """NoOpQAStrategy() with no args still works after adding __init__."""
+        strategy = NoOpQAStrategy()
+        assert strategy.is_noop is True


### PR DESCRIPTION
## Summary

- Adds `config: EngagementConfig | None` parameter to `discover_plugin()` so QA strategy plugins receive `model`, `token_budget`, and `client_name` at construction time
- Extracts `_instantiate_plugin()` helper to deduplicate the kwargs-with-TypeError-fallback pattern that appeared in both the named-plugin and priority-loop paths
- Adds `_QA_STRATEGY_GROUP` constant (replaces bare string literal, consistent with `ADAPTER_GROUP`/`RENDERER_GROUP` pattern)
- `NoOpQAStrategy.__init__` uses `**_kwargs` instead of named params -- honest that args are intentionally ignored
- All three CLI commands (`run`, `consolidate`, `replay`) pass config through to `discover_plugin`

## Test plan

- [ ] `tests/unit/cli/test_helpers.py` -- covers named path, loop path, TypeError fallback, non-TypeError passthrough, non-QA group (no kwargs), and `config=None` cases
- [ ] `tests/unit/qa/test_noop.py` -- covers kwargs construction and zero-arg construction of `NoOpQAStrategy`
- [ ] All 41 tests in these two files pass (`pytest tests/unit/cli/test_helpers.py tests/unit/qa/test_noop.py --no-cov`)