### PR TITLE
feat: expand EventType Literal for extensibility

### DIFF
--- a/src/gxassessms/pipeline/state.py
+++ b/src/gxassessms/pipeline/state.py
@@ -33,6 +33,11 @@ EventType = Literal[
     "manual_finding_added",
     "lock_broken",
     "stale_recovery",
+    "narrative_edit",
+    "narrative_approval",
+    "rerender",
+    "token_usage",
+    "manual_merge",
 ]
 
 # Derive valid values from the EventType Literal for runtime validation


### PR DESCRIPTION
## Summary

- Adds 5 new values to `EventType` Literal in `pipeline/state.py`: `narrative_edit`, `narrative_approval`, `rerender`, `token_usage`, `manual_merge`
- These are extension points for downstream consumers that need richer event-journal tracking (narrative lifecycle, re-rendering, usage metrics, manual dedup)
- `_VALID_EVENT_TYPES` frozenset auto-derives via `get_args()` -- no other code changes required

## Test plan

- [x] Full test suite passes (92% coverage)
- [x] All pre-commit hooks pass (ruff, pyright, detect-secrets)
- [x] Pure additive change -- no existing behavior affected