### PR TITLE
chore: lower Python requirement from 3.14 to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install semgrep
         run: pip install semgrep
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install -e ".[dev]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Design spec: `../gxassessms-guardantix/docs/specs/2026-03-25-gxassessms-architec
 
 ## Tech Stack
 
-- Python >=3.14, Pydantic, Click, Rich, httpx
+- Python >=3.12, Pydantic, Click, Rich, httpx
 - Node.js for report renderers (guardantix-docx-kit, guardantix-pptx-kit)
 - SQLite (WAL mode) + filesystem for persistence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Microsoft Ecosystem Assessment Orchestrator"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 authors = [
     { name = "Rick Passero", email = "rick@guardantix.com" },
 ]
@@ -95,7 +95,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 line-length = 100
 src = ["src", "tests"]
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src"],
     "extraPaths": ["src", "."],
-    "pythonVersion": "3.14",
+    "pythonVersion": "3.12",
     "typeCheckingMode": "strict",
     "reportMissingTypeStubs": false,
     "reportUnusedImport": false,

--- a/tests/unit/core/test_schema_sync.py
+++ b/tests/unit/core/test_schema_sync.py
@@ -154,7 +154,7 @@ class TestSeverityCoverage:
                 if not isinstance(value, Severity):
                     try:
                         Severity(value)
-                    except ValueError, KeyError:
+                    except (ValueError, KeyError):
                         pytest.fail(
                             f"{type(adapter).__name__}.severity_map[{key!r}] "
                             f"= {value!r} is not a valid Severity member."
@@ -180,7 +180,7 @@ class TestCategoryCoverage:
                 if not isinstance(value, Category):
                     try:
                         Category(value)
-                    except ValueError, KeyError:
+                    except (ValueError, KeyError):
                         pytest.fail(
                             f"{type(adapter).__name__}.category_map[{key!r}] "
                             f"= {value!r} is not a valid Category member."

--- a/tests/unit/core/test_schema_sync.py
+++ b/tests/unit/core/test_schema_sync.py
@@ -154,7 +154,7 @@ class TestSeverityCoverage:
                 if not isinstance(value, Severity):
                     try:
                         Severity(value)
-                    except (ValueError, KeyError):
+                    except ValueError:
                         pytest.fail(
                             f"{type(adapter).__name__}.severity_map[{key!r}] "
                             f"= {value!r} is not a valid Severity member."
@@ -180,7 +180,7 @@ class TestCategoryCoverage:
                 if not isinstance(value, Category):
                     try:
                         Category(value)
-                    except (ValueError, KeyError):
+                    except ValueError:
                         pytest.fail(
                             f"{type(adapter).__name__}.category_map[{key!r}] "
                             f"= {value!r} is not a valid Category member."


### PR DESCRIPTION
## Summary
- Lowers `requires-python` from `>=3.14` to `>=3.12` for broader distribution compatibility
- Parenthesizes 2 bare-tuple `except` clauses (PEP 758, Python 3.14-only syntax)
- Updates ruff `target-version` and CI workflow Python pins to 3.12

## Test plan
- [ ] CI passes on 3.12 (lint, format, pyright, tests on Linux + Windows)
- [ ] Verify no other 3.13/3.14-only syntax remains (`ruff check` with `py312` target catches these)