### PR TITLE
docs: user-facing documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,61 +2,80 @@
 
 **Microsoft Ecosystem Assessment Orchestrator**
 
-Chains together best-in-class security and compliance tools, consolidates findings into a unified schema, and produces branded Guardantix deliverables.
+GxAssessMS runs security and compliance tools against your Microsoft 365 and Azure
+tenants, consolidates the results into a unified set of findings, and produces a
+single assessment report. You don't need to learn how each tool works individually --
+configure what you want assessed and let `mseco` handle the rest.
 
-## Integrated Tools
+## What It Does
 
-| Tool | Scope |
-|------|-------|
-| [ScubaGear](https://github.com/cisagov/ScubaGear) | M365 security baseline (CISA SCuBA) |
-| [Maester](https://github.com/maester365/maester) | Entra ID / M365 security testing |
-| [Monkey365](https://github.com/silverhack/monkey365) | Azure / M365 / Entra ID compliance |
+- **Runs multiple tools for you** -- ScubaGear, Maester, Monkey365, Prowler, Secure
+  Score, Azure Advisor, and M365 Assess, all from a single config file
+- **Consolidates and deduplicates** -- overlapping findings from different tools are
+  merged so nothing is double-counted
+- **Assigns severity and priority** -- each finding gets a severity rating and
+  remediation timeline
+- **Produces a report** -- generates a .docx deliverable summarizing findings,
+  severity breakdown, and recommended remediation roadmap
 
-## Architecture
+## Quick Start
 
-```
-Client M365 Tenant
-        |
-   GxAssessMS Orchestrator
-        |
-   +----+----+----+
-   |    |    |    |
-ScubaGear Maester Monkey365 ...
-   |    |    |    |
-   +----+----+----+
-        |
-  Unified Finding Schema
-        |
-  Branded Gx Deliverables
+**Requirements:** Python 3.12+. See [Installation Guide](docs/installation.md) for
+full setup including PowerShell modules and Azure configuration.
+
+```bash
+pip install gxassessms
 ```
 
-## CLI
+Create a config file (`assessment.yaml`):
 
+```yaml
+client:
+  name: "Contoso"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+auth:
+  method: "client_credential"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+  client_secret_env: "AZURE_CLIENT_SECRET"  # pragma: allowlist secret
+
+tools:
+  scubagear:
+    enabled: true
+    modules: ["AAD", "EXO", "SharePoint", "Teams"]
 ```
-mseco run <config.yaml>             Run full assessment pipeline
-mseco collect <config.yaml>         Run collection stage only
-mseco preflight <config.yaml>       Validate config, prerequisites, auth, renderers
-mseco adapters list                 Show discovered adapters
-mseco adapters check                Run prerequisite checks (baseline policy)
-mseco adapters scaffold <name>      Generate new adapter package from template
-mseco compute-module-hash           Compute sha256tree:v1 hash for a PowerShell module
-mseco engagement list|archive|...   Manage engagement lifecycle
-mseco report <config.yaml>          Generate reports from existing engagement
-mseco replay <config.yaml>          Re-run pipeline from persisted raw outputs
+
+Run the assessment:
+
+```bash
+mseco preflight assessment.yaml   # validate config and prerequisites
+mseco run assessment.yaml          # run the full pipeline
 ```
 
-## Module Provenance
+## Documentation
 
-PowerShell modules (ScubaGear, Maester) are verified before execution:
+| Guide | Description |
+|-------|-------------|
+| [Installation](docs/installation.md) | Python, PowerShell modules, Azure app registration, verification |
+| [Quick Start Tutorial](docs/quickstart.md) | Your first assessment, step by step |
+| [Configuration Reference](docs/configuration.md) | Every config field explained |
+| [CLI Reference](docs/cli-reference.md) | All `mseco` commands with examples |
+| [Adapter Guide](docs/adapters.md) | What each tool assesses and how to configure it |
+| [Security Model](docs/security.md) | Module provenance, data handling, trust model |
 
-- **Version pinning**: semver range constraints per adapter policy
-- **Tree hash integrity**: `sha256tree:v1` hash of the full module directory
-- **Signature verification**: Authenticode when available, hash-only fallback
-- **Staging**: modules are copied to a private temp directory and verified there (eliminates TOCTOU)
-- **Fail-closed**: unrecognized modules, ambiguous candidates, and confinement violations block execution
+## Supported Tools
 
-See `docs/superpowers/specs/2026-04-03-powershell-module-provenance-design.md` for the full design.
+| Tool | What It Assesses | Type |
+|------|-----------------|------|
+| [ScubaGear](https://github.com/cisagov/ScubaGear) | M365 security baseline (CISA SCuBA) | PowerShell module |
+| [Maester](https://github.com/maester365/maester) | Entra ID / M365 security testing | PowerShell module |
+| [Monkey365](https://github.com/silverhack/monkey365) | Azure / M365 / Entra ID compliance | PowerShell module |
+| [Prowler](https://github.com/prowler-cloud/prowler) | Multi-cloud security (Azure focus) | Python CLI |
+| Secure Score | Microsoft Secure Score | Graph API |
+| Azure Advisor | Azure optimization recommendations | Management API |
+| M365 Assess | Custom M365 assessment framework | PowerShell modules |
 
-## Status
+## License
 
-Early development.
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ auth:
 tools:
   scubagear:
     enabled: true
+    output_dir: "./output/scubagear"
     modules: ["AAD", "EXO", "SharePoint", "Teams"]
 ```
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,200 @@
+# Adapter Guide
+
+Adapters connect `mseco` to individual security and compliance tools. Each
+adapter knows how to run a tool, read its output, and map findings to the
+unified schema.
+
+**Key points:**
+
+- Adapters are discovered automatically at startup via entry points. Run
+  `mseco adapters list` to see what's available.
+- Adapters run in parallel. If one fails, the others continue.
+- You enable adapters in your [config file](configuration.md) under the
+  `tools` section.
+
+## ScubaGear
+
+**What it assesses:** Microsoft 365 security configuration against the CISA
+SCuBA (Secure Cloud Business Applications) baseline. Covers Entra ID,
+Exchange Online, SharePoint, Teams, Defender, and Power Platform.
+
+**Type:** PowerShell module.
+
+**Requirements:**
+- PowerShell 7+
+- ScubaGear module v1.5.0 -- v1.x (install with `Install-Module -Name ScubaGear`)
+- API permissions: `Directory.Read.All`, `Policy.Read.All` (Microsoft Graph)
+
+**Config options:**
+
+```yaml
+tools:
+  scubagear:
+    enabled: true
+    modules: ["AAD", "Defender", "EXO", "PowerPlatform", "SharePoint", "Teams"]
+    timeout: 1800    # default: 1800 (30 minutes)
+```
+
+The `modules` field controls which M365 products to assess. Valid values:
+`AAD`, `Defender`, `EXO`, `PowerPlatform`, `SharePoint`, `Teams`. Omit the
+field to assess all of them.
+
+**Notes:** ScubaGear is the slowest adapter -- large tenants with thousands of
+users can take 15-30 minutes. Start with a subset of modules for initial testing.
+
+## Maester
+
+**What it assesses:** Entra ID and Microsoft 365 security configuration using
+the Maester test framework. Tests cover conditional access policies, MFA
+configuration, privileged identity management, and more.
+
+**Type:** PowerShell module.
+
+**Requirements:**
+- PowerShell 7+
+- Maester module v1.0.0 -- v1.x (install with `Install-Module -Name Maester`)
+- API permissions: `Directory.Read.All`, `Policy.Read.All` (Microsoft Graph)
+
+**Config options:**
+
+```yaml
+tools:
+  maester:
+    enabled: true
+    timeout: 600
+```
+
+**Notes:** Maester overlaps with ScubaGear on Entra ID checks. Running both
+gives broader coverage -- the consolidation engine deduplicates shared findings.
+
+## Monkey365
+
+**What it assesses:** Azure, Microsoft 365, and Entra ID compliance. Covers
+storage accounts, networking, identity, and M365 service configuration.
+
+**Type:** PowerShell module.
+
+**Requirements:**
+- PowerShell 7+
+- monkey365 module v1.0.0 -- v1.x (install with `Install-Module -Name monkey365`)
+- API permissions: `Directory.Read.All` (Microsoft Graph), Reader role on Azure subscription
+
+**Config options:**
+
+```yaml
+tools:
+  monkey365:
+    enabled: true
+    timeout: 900
+```
+
+**Notes:** Monkey365 is the primary adapter for Azure infrastructure checks.
+If your client has Azure resources beyond M365, enable this one.
+
+## Prowler
+
+**What it assesses:** Multi-cloud security posture with strong Azure coverage.
+Checks against CIS benchmarks, security best practices, and compliance
+frameworks.
+
+**Type:** Python CLI tool.
+
+**Requirements:**
+- Prowler installed (`pip install prowler` -- requires Python 3.10-3.12)
+- API permissions: Reader role on Azure subscription
+
+**Config options:**
+
+```yaml
+tools:
+  prowler:
+    enabled: true
+    timeout: 1200
+```
+
+**Notes:** Prowler runs as a separate Python process. It has its own Python
+version requirements (3.10-3.12) which may differ from GxAssessMS.
+
+## Secure Score
+
+**What it assesses:** Microsoft Secure Score -- Microsoft's own security posture
+rating for your M365 tenant. Provides a score and improvement actions.
+
+**Type:** API-based (Microsoft Graph). No PowerShell required.
+
+**Requirements:**
+- API permissions: `SecurityEvents.Read.All` (Microsoft Graph)
+
+**Config options:**
+
+```yaml
+tools:
+  securescore: true    # shorthand is usually enough
+```
+
+**Notes:** Lightweight -- runs in seconds. The findings come with Microsoft's own
+severity ratings, which are mapped to the unified schema.
+
+## Azure Advisor
+
+**What it assesses:** Azure Advisor recommendations covering security,
+reliability, performance, cost, and operational excellence.
+
+**Type:** API-based (Azure Management API). No PowerShell required.
+
+**Requirements:**
+- `subscription_id` set in the `client` section of your config
+- Reader role on the Azure subscription
+
+**Config options:**
+
+```yaml
+tools:
+  azureadvisor: true
+```
+
+**Notes:** Requires `client.subscription_id` in your config. Findings use
+Azure Advisor's own impact ratings.
+
+## M365 Assess
+
+**What it assesses:** Custom Microsoft 365 assessment framework with coverage
+mapping to CIS benchmarks.
+
+**Type:** PowerShell modules.
+
+**Requirements:**
+- PowerShell 7+
+- `Microsoft.Graph.Authentication` and `ExchangeOnlineManagement` modules
+
+**Config options:**
+
+```yaml
+tools:
+  m365_assess:
+    enabled: true
+```
+
+## Choosing Which Adapters to Run
+
+Start simple and add tools as needed:
+
+| Scenario | Recommended Adapters |
+|----------|---------------------|
+| M365 only (first assessment) | ScubaGear + Maester |
+| M365 + Azure infrastructure | ScubaGear + Maester + Monkey365 |
+| Comprehensive (all available data) | ScubaGear + Maester + Monkey365 + Secure Score + Azure Advisor |
+| Quick posture check | Secure Score (runs in seconds) |
+
+You can always add more adapters later and re-run. The pipeline preserves
+previous results.
+
+## How Findings Overlap
+
+Multiple tools often flag the same issue. For example, both ScubaGear and
+Maester check whether MFA is enforced for administrators. The consolidation
+engine detects these overlaps and merges them into a single finding, keeping
+the most detailed information from each source.
+
+You don't need to worry about double-counting. The report shows deduplicated
+findings with source attribution so you can see which tools contributed.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -31,6 +31,7 @@ Exchange Online, SharePoint, Teams, Defender, and Power Platform.
 tools:
   scubagear:
     enabled: true
+    output_dir: "./output/scubagear"
     modules: ["AAD", "Defender", "EXO", "PowerPlatform", "SharePoint", "Teams"]
     timeout: 1800    # default: 1800 (30 minutes)
 ```
@@ -61,6 +62,7 @@ configuration, privileged identity management, and more.
 tools:
   maester:
     enabled: true
+    output_dir: "./output/maester"
     timeout: 600
 ```
 
@@ -85,6 +87,7 @@ storage accounts, networking, identity, and M365 service configuration.
 tools:
   monkey365:
     enabled: true
+    output_dir: "./output/monkey365"
     timeout: 900
 ```
 
@@ -109,6 +112,7 @@ frameworks.
 tools:
   prowler:
     enabled: true
+    output_dir: "./output/prowler"
     timeout: 1200
 ```
 
@@ -129,7 +133,9 @@ rating for your M365 tenant. Provides a score and improvement actions.
 
 ```yaml
 tools:
-  securescore: true    # shorthand is usually enough
+  securescore:
+    enabled: true
+    output_dir: "./output/securescore"
 ```
 
 **Notes:** Lightweight -- runs in seconds. The findings come with Microsoft's own
@@ -150,7 +156,9 @@ reliability, performance, cost, and operational excellence.
 
 ```yaml
 tools:
-  azureadvisor: true
+  azureadvisor:
+    enabled: true
+    output_dir: "./output/azureadvisor"
 ```
 
 **Notes:** Requires `client.subscription_id` in your config. Findings use
@@ -174,11 +182,11 @@ tools:
   m365_assess:
     enabled: true
     script_dir: "/path/to/M365-Assess"     # directory containing Invoke-M365Assessment.ps1
-    output_dir: "/path/to/m365-output"     # where raw output is written
+    output_dir: "./output/m365_assess"
 ```
 
-Both `script_dir` and `output_dir` are required for this adapter. `script_dir`
-must point to the directory containing `Invoke-M365Assessment.ps1`.
+`script_dir` is required for this adapter and must point to the directory
+containing `Invoke-M365Assessment.ps1`.
 
 ## Choosing Which Adapters to Run
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -173,7 +173,12 @@ mapping to CIS benchmarks.
 tools:
   m365_assess:
     enabled: true
+    script_dir: "/path/to/M365-Assess"     # directory containing Invoke-M365Assessment.ps1
+    output_dir: "/path/to/m365-output"     # where raw output is written
 ```
+
+Both `script_dir` and `output_dir` are required for this adapter. `script_dir`
+must point to the directory containing `Invoke-M365Assessment.ps1`.
 
 ## Choosing Which Adapters to Run
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,336 @@
+# CLI Reference
+
+All commands are run as `mseco <command>`. Use `--help` on any command for
+built-in documentation.
+
+## Global Options
+
+These options are available on every command:
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `--version` | | | Show version and exit |
+| `--log-level` | `debug`, `info`, `warning`, `error` | `warning` | Set logging verbosity |
+| `--log-format` | `rich`, `json` | `rich` | `rich` for human-readable, `json` for log aggregation |
+| `-v` / `--verbose` | | | Shortcut for `--log-level debug` |
+
+## mseco run
+
+Run the full assessment pipeline (COLLECT through RENDER).
+
+```
+mseco run [OPTIONS] CONFIG_PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--engagement-id TEXT` | Resume or re-run an existing engagement instead of creating a new one |
+| `--dry-run` | Validate config and report execution plan without running tools |
+| `--force-stage STAGE` | Invalidate a specific stage and re-run from there (requires `--engagement-id`). Values: `collect`, `parse`, `consolidate`, `qa_review`, `render` |
+| `--rerun` | Re-run all stages regardless of state (requires `--engagement-id`) |
+| `--qa-strategy TEXT` | Override QA strategy selection |
+
+**Examples:**
+
+```bash
+# New assessment
+mseco run assessment.yaml
+
+# Dry run (validate only)
+mseco run --dry-run assessment.yaml
+
+# Re-run from consolidation
+mseco run --engagement-id abc123 --force-stage consolidate assessment.yaml
+```
+
+## mseco preflight
+
+Validate config, prerequisites, auth, and renderer dependencies.
+
+```
+mseco preflight [OPTIONS] CONFIG_PATH
+```
+
+No additional options. Run this before every assessment.
+
+**Example:**
+
+```bash
+mseco preflight assessment.yaml
+```
+
+## mseco collect
+
+Run assessment tools only (no parsing, consolidation, or reporting).
+
+```
+mseco collect [OPTIONS] CONFIG_PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--engagement-id TEXT` | Target an existing engagement |
+
+**Example:**
+
+```bash
+mseco collect assessment.yaml
+```
+
+## mseco report
+
+Generate report deliverables from existing consolidated findings. The
+engagement must be in QA_APPROVED state.
+
+```
+mseco report [OPTIONS] CONFIG_PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--engagement-id TEXT` | **(Required)** Engagement to render |
+
+**Example:**
+
+```bash
+mseco report --engagement-id abc123 assessment.yaml
+```
+
+## mseco replay
+
+Re-run the pipeline from persisted raw output without re-executing tools.
+
+```
+mseco replay [OPTIONS] ENGAGEMENT_ID
+```
+
+| Option | Description |
+|--------|-------------|
+| `--from STAGE` | Stage to replay from: `parse`, `consolidate`, `qa`, `report`. Default: `parse` |
+| `--qa-strategy TEXT` | Override QA strategy selection |
+
+**Examples:**
+
+```bash
+# Re-run from parse stage
+mseco replay abc123
+
+# Re-run only from consolidation
+mseco replay --from consolidate abc123
+```
+
+## mseco consolidate
+
+Re-run normalization and deduplication from persisted data.
+
+```
+mseco consolidate [OPTIONS] CONFIG_PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--engagement-id TEXT` | **(Required)** Engagement to consolidate |
+| `--reparse` | Start from raw output (re-parse + re-normalize + re-consolidate) |
+| `--qa-strategy TEXT` | Override QA strategy selection |
+
+**Example:**
+
+```bash
+mseco consolidate --engagement-id abc123 assessment.yaml
+mseco consolidate --engagement-id abc123 --reparse assessment.yaml
+```
+
+## mseco review
+
+Launch the browser-based interface for reviewing an engagement. Requires an
+extension package with a review implementation.
+
+```
+mseco review [OPTIONS] ENGAGEMENT_ID
+```
+
+## mseco engagement
+
+Manage assessment engagements.
+
+### mseco engagement create
+
+```
+mseco engagement create [OPTIONS] CONFIG_PATH
+```
+
+Create a new engagement record, directory structure, and config snapshot.
+
+### mseco engagement list
+
+```
+mseco engagement list
+```
+
+List all engagements with their state and timestamps.
+
+### mseco engagement status
+
+```
+mseco engagement status ENGAGEMENT_ID
+```
+
+Show detailed status for a specific engagement.
+
+### mseco engagement archive
+
+```
+mseco engagement archive ENGAGEMENT_ID
+```
+
+Compress raw output to cold storage. Structured data stays in the database
+for reference. Use `restore` to decompress later.
+
+### mseco engagement restore
+
+```
+mseco engagement restore ENGAGEMENT_ID
+```
+
+Restore an archived engagement for re-analysis.
+
+### mseco engagement export
+
+```
+mseco engagement export [OPTIONS] ENGAGEMENT_ID
+```
+
+| Option | Description |
+|--------|-------------|
+| `--format` | `yaml` or `json`. Default: yaml |
+
+Export engagement metadata (ID, client, state, timestamps, tool list). Does not
+include findings or client data.
+
+### mseco engagement purge
+
+```
+mseco engagement purge --confirm ENGAGEMENT_ID
+```
+
+**Permanently delete** all data for an engagement. This is irreversible. Deletes
+database records and filesystem artifacts. Writes an audit manifest before
+deletion.
+
+The `--confirm` flag is required.
+
+## mseco adapters
+
+Manage assessment tool adapters.
+
+### mseco adapters list
+
+```
+mseco adapters list
+```
+
+Show all discovered adapters, their capabilities, and status.
+
+### mseco adapters check
+
+```
+mseco adapters check
+```
+
+Run prerequisite and provenance checks for all discovered adapters.
+
+### mseco adapters scaffold
+
+```
+mseco adapters scaffold NAME
+```
+
+Generate a new adapter package from the standard template.
+
+## mseco ingest
+
+Import raw tool output that was collected outside of `mseco`.
+
+```
+mseco ingest [OPTIONS] ENGAGEMENT_ID
+```
+
+| Option | Description |
+|--------|-------------|
+| `--tool TEXT` | **(Required)** Tool slug (e.g., `scubagear`) |
+| `--from DIRECTORY` | Directory containing raw tool output |
+| `--replace` | Replace existing raw output for this tool |
+| `--schema-version TEXT` | Override default schema version |
+| `--run-at TEXT` | ISO 8601 timestamp for when the tool was run |
+| `--operator TEXT` | Override operator identity |
+
+**Example:**
+
+```bash
+mseco ingest --tool scubagear --from ./scuba-output abc123
+```
+
+## mseco compute-module-hash
+
+Compute the `sha256tree:v1` hash for a PowerShell module directory. Used for
+populating adapter provenance policies.
+
+```
+mseco compute-module-hash --manifest-path PATH
+```
+
+| Option | Description |
+|--------|-------------|
+| `--manifest-path FILE` | **(Required)** Path to the module `.psd1` manifest |
+
+## mseco analytics
+
+Analytics and insight commands. Requires an extension package with analytics
+support.
+
+```
+mseco analytics COMMAND
+```
+
+| Subcommand | Description |
+|-----------|-------------|
+| `cost` | Token usage and cost per engagement |
+| `coverage` | Tool coverage across engagements |
+| `tuning` | Tuning recommendations from engagement history |
+
+## Common Workflows
+
+**Full assessment (typical):**
+
+```bash
+mseco preflight assessment.yaml    # validate everything first
+mseco run assessment.yaml          # run the pipeline
+mseco engagement status <id>       # check the result
+```
+
+**Re-generate a report:**
+
+```bash
+mseco report --engagement-id <id> assessment.yaml
+```
+
+**Resume after a partial failure:**
+
+```bash
+mseco replay <id>                  # re-run from parse stage
+mseco replay --from consolidate <id>  # re-run from consolidation only
+```
+
+**Check what's installed:**
+
+```bash
+mseco adapters list                # show discovered adapters
+mseco adapters check               # run prerequisite checks
+```
+
+**Import externally-collected output:**
+
+```bash
+mseco ingest --tool scubagear --from ./client-data <id>
+mseco replay <id>                  # process the imported data
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,274 @@
+# Configuration Reference
+
+GxAssessMS is configured through a YAML file passed to most `mseco` commands.
+The config is validated strictly -- misspelled keys and wrong types produce
+immediate errors, not silent surprises.
+
+## Config Sections
+
+| Section | Required | Purpose |
+|---------|----------|---------|
+| `client` | Yes | Who is being assessed |
+| `auth` | Yes | How to authenticate to the tenant |
+| `tools` | No | Which assessment tools to run and how |
+| `report` | No | Output format and theme |
+| `pipeline` | No | Execution tuning |
+
+## `client`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Client or organization name (appears in reports) |
+| `tenant_id` | string | Yes | Microsoft Entra tenant ID (GUID). Must match `auth.tenant_id` |
+| `subscription_id` | string | No | Azure subscription ID (required for Azure Advisor) |
+
+```yaml
+client:
+  name: "Contoso"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  subscription_id: "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj"  # optional
+```
+
+## `auth`
+
+Three authentication methods are supported. Choose based on your scenario.
+
+### `client_credential` with Secret
+
+Best for: automated or unattended assessment runs.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `method` | string | Yes | `"client_credential"` |
+| `tenant_id` | string | Yes | Must match `client.tenant_id` |
+| `client_id` | string | Yes | Application (client) ID from your app registration |
+| `client_secret_env` | string | Yes* | Name of the environment variable holding the secret. **Not the secret itself.** |
+
+*Either `client_secret_env` or `certificate_path` is required.
+
+```yaml
+auth:
+  method: "client_credential"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+  client_secret_env: "AZURE_CLIENT_SECRET"  # pragma: allowlist secret
+```
+
+### `client_credential` with Certificate
+
+Best for: production deployments with higher security requirements.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `method` | string | Yes | `"client_credential"` |
+| `tenant_id` | string | Yes | Must match `client.tenant_id` |
+| `client_id` | string | Yes | Application (client) ID |
+| `certificate_path` | string | Yes* | Path to the PEM certificate file |
+
+```yaml
+auth:
+  method: "client_credential"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+  certificate_path: "/path/to/cert.pem"
+```
+
+### `device_code`
+
+Best for: one-off runs where you're at the keyboard. Opens a browser for
+interactive sign-in.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `method` | string | Yes | `"device_code"` |
+| `tenant_id` | string | Yes | Must match `client.tenant_id` |
+| `client_id` | string | Yes | Application (client) ID |
+
+```yaml
+auth:
+  method: "device_code"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+```
+
+### `interactive`
+
+Best for: browser-based sign-in flow.
+
+Same fields as `device_code`. Uses the system browser instead of a device code
+prompt.
+
+```yaml
+auth:
+  method: "interactive"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+```
+
+## `tools`
+
+Each tool can be enabled with a shorthand or expanded form.
+
+**Shorthand:**
+
+```yaml
+tools:
+  scubagear: true
+  maester: false
+```
+
+**Expanded form:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Whether to run this tool |
+| `modules` | list of strings | `[]` | Which modules/products to assess (tool-specific) |
+| `timeout` | integer | varies | Maximum seconds for tool execution |
+| `output_dir` | string | `""` | Custom output directory |
+| `extra_args` | list of strings | `[]` | Additional arguments passed to the tool |
+| `module_policy_override` | object | none | Advanced: narrow module provenance policy (see below) |
+
+```yaml
+tools:
+  scubagear:
+    enabled: true
+    modules: ["AAD", "EXO", "SharePoint", "Teams"]
+    timeout: 1200
+
+  maester:
+    enabled: true
+    timeout: 600
+
+  securescore: true    # shorthand -- just enable with defaults
+```
+
+**Tool-specific module values:**
+
+| Tool | Valid `modules` | Default (if omitted) |
+|------|-----------------|---------------------|
+| ScubaGear | `AAD`, `Defender`, `EXO`, `PowerPlatform`, `SharePoint`, `Teams` | All modules |
+| Others | Not applicable -- no module selection | N/A |
+
+**Default timeouts:**
+
+| Tool | Default Timeout |
+|------|----------------|
+| ScubaGear | 1800s (30 min) |
+| All others | Adapter-specific |
+
+See [Adapter Guide](adapters.md) for per-tool configuration details.
+
+### Module Provenance Overrides (Advanced)
+
+This is a per-tool nested field for additional security hardening. It narrows
+the adapter's built-in provenance policy -- it can restrict to a specific
+version or hash, but never loosen the baseline.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version_range` | string | Exact version pin, e.g., `"==1.5.2"` |
+| `pinned_package_hashes` | list of strings | Specific `sha256tree:v1:...` hashes to allow |
+
+```yaml
+tools:
+  scubagear:
+    enabled: true
+    module_policy_override:
+      version_range: "==1.5.2"
+      pinned_package_hashes:
+        - "sha256tree:v1:abc123..."
+```
+
+Most operators won't need this. See [Security Model](security.md) for the full
+provenance verification model.
+
+## `report`
+
+| Field | YAML Key | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| Report formats | `formats` | list of strings | `["docx"]` | Output formats to generate |
+| Theme | `theme` | string | `"basic"` | Report visual theme |
+| Logo | `logo_path` | string | none | Path to a logo image for the report |
+
+Additional report formats and themes may be available through extension packages.
+
+```yaml
+report:
+  formats: ["docx"]
+  theme: "basic"
+  logo_path: "assets/logo.png"
+```
+
+## `pipeline`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_parallel` | integer | `4` | Maximum tools to run simultaneously. Higher = faster but more memory |
+| `qa_model` | string | `"claude-sonnet-4-6"` | Model for QA review (if a QA strategy is installed) |
+| `qa_token_budget` | integer | `100000` | Token budget for QA review |
+
+```yaml
+pipeline:
+  max_parallel: 3
+  qa_model: "claude-sonnet-4-6"
+  qa_token_budget: 100000
+```
+
+The `qa_model` and `qa_token_budget` fields only take effect when a QA strategy
+extension is installed. With the default no-op strategy, they're ignored.
+
+## Complete Example
+
+```yaml
+client:
+  name: "Contoso Healthcare"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  subscription_id: "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj"
+
+auth:
+  method: "client_credential"
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  client_id: "11111111-2222-3333-4444-555555555555"
+  client_secret_env: "AZURE_CLIENT_SECRET"  # pragma: allowlist secret
+
+tools:
+  scubagear:
+    enabled: true
+    modules: ["AAD", "Defender", "EXO", "SharePoint", "Teams"]
+    timeout: 1800
+  maester:
+    enabled: true
+    timeout: 600
+  securescore: true
+  azureadvisor: true
+
+report:
+  formats: ["docx"]
+  theme: "basic"
+
+pipeline:
+  max_parallel: 3
+```
+
+## Validation Errors
+
+When `mseco preflight` or `mseco run` detects a config problem, it reports the
+specific issue. Common errors:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `client.name is empty` | Name field missing or blank | Add `name: "Your Client"` |
+| `client.tenant_id is empty` | Tenant ID missing | Add your M365 tenant GUID |
+| `auth.tenant_id does not match client.tenant_id` | Mismatched tenant IDs | Make them identical |
+| `client_credential requires client_secret_env or certificate_path` | Neither secret nor cert configured | Add one of these fields |
+| `Invalid value type for 'enabled'` | Used a string like `"true"` instead of `true` | Remove the quotes |
+| `Invalid value type for 'timeout'` | Used `true` instead of a number | Set an integer value |
+| `Unknown section` | Typo in a top-level key | Check spelling against this reference |
+| `Extra inputs are not permitted` | Typo in a field name | Check spelling against the field tables above |
+
+**Warnings** (non-blocking):
+
+| Warning | Meaning |
+|---------|---------|
+| `client_secret_env provided but auth method is device_code` | Secret is ignored for interactive methods |
+| `No tools are enabled` | Pipeline will run but produce no findings |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,8 @@ tools:
 | `enabled` | boolean | `false` | Whether to run this tool |
 | `modules` | list of strings | `[]` | Which modules/products to assess (tool-specific) |
 | `timeout` | integer | varies | Maximum seconds for tool execution |
-| `output_dir` | string | `""` | Custom output directory |
+| `output_dir` | string | `""` | Custom output directory (required for M365 Assess) |
+| `script_dir` | string | `""` | Tool script directory (required for M365 Assess) |
 | `extra_args` | list of strings | `[]` | Additional arguments passed to the tool |
 | `module_policy_override` | object | none | Advanced: narrow module provenance policy (see below) |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ tools:
 | `enabled` | boolean | `false` | Whether to run this tool |
 | `modules` | list of strings | `[]` | Which modules/products to assess (tool-specific) |
 | `timeout` | integer | varies | Maximum seconds for tool execution |
-| `output_dir` | string | `""` | Custom output directory (required for M365 Assess) |
+| `output_dir` | string | `""` | Output directory for raw tool data (required for all adapters) |
 | `script_dir` | string | `""` | Tool script directory (required for M365 Assess) |
 | `extra_args` | list of strings | `[]` | Additional arguments passed to the tool |
 | `module_policy_override` | object | none | Advanced: narrow module provenance policy (see below) |
@@ -133,14 +133,18 @@ tools:
 tools:
   scubagear:
     enabled: true
+    output_dir: "./output/scubagear"
     modules: ["AAD", "EXO", "SharePoint", "Teams"]
     timeout: 1200
 
   maester:
     enabled: true
+    output_dir: "./output/maester"
     timeout: 600
 
-  securescore: true    # shorthand -- just enable with defaults
+  securescore:
+    enabled: true
+    output_dir: "./output/securescore"
 ```
 
 **Tool-specific module values:**
@@ -235,13 +239,19 @@ auth:
 tools:
   scubagear:
     enabled: true
+    output_dir: "./output/scubagear"
     modules: ["AAD", "Defender", "EXO", "SharePoint", "Teams"]
     timeout: 1800
   maester:
     enabled: true
+    output_dir: "./output/maester"
     timeout: 600
-  securescore: true
-  azureadvisor: true
+  securescore:
+    enabled: true
+    output_dir: "./output/securescore"
+  azureadvisor:
+    enabled: true
+    output_dir: "./output/azureadvisor"
 
 report:
   formats: ["docx"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,254 @@
+# Installation
+
+## Requirements
+
+| Requirement | Version | Needed For |
+|-------------|---------|------------|
+| Python | 3.12+ | Core package |
+| PowerShell | 7+ | ScubaGear, Maester, Monkey365 adapters |
+| Node.js | 18+ | Report rendering (.docx, .pptx) |
+
+PowerShell and Node.js are only required if you use the adapters or report
+formats that depend on them. The API-based adapters (Secure Score, Azure
+Advisor) and Prowler need only Python.
+
+## Installing Python
+
+**Windows:**
+
+```powershell
+# Option 1: Download from python.org
+# https://www.python.org/downloads/ -- choose 3.12 or later
+
+# Option 2: winget
+winget install Python.Python.3.12
+```
+
+**Linux (Ubuntu/Debian):**
+
+```bash
+sudo apt update
+sudo apt install python3 python3-pip python3-venv
+```
+
+**Verify:**
+
+```bash
+python3 --version
+# Python 3.12.x or later
+```
+
+## Installing GxAssessMS
+
+Create a virtual environment (recommended) and install:
+
+```bash
+python3 -m venv .venv
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows PowerShell
+.venv\Scripts\Activate.ps1
+
+pip install gxassessms
+```
+
+**From source (development):**
+
+```bash
+git clone https://github.com/Guardantix/gxassessms.git
+cd gxassessms
+pip install -e ".[dev]"
+```
+
+## PowerShell Modules
+
+If you plan to use ScubaGear, Maester, or Monkey365, install the required
+PowerShell modules. Each module is verified for integrity before execution --
+see [Security Model](security.md) for details.
+
+**ScubaGear** (CISA SCuBA M365 baseline):
+
+```powershell
+Install-Module -Name ScubaGear -Scope CurrentUser
+```
+
+Required version: 1.5.0 or later (below 2.0.0).
+
+**Maester** (Entra ID / M365 security):
+
+```powershell
+Install-Module -Name Maester -Scope CurrentUser
+```
+
+Required version: 1.0.0 or later (below 2.0.0).
+
+**Monkey365** (Azure / M365 / Entra ID compliance):
+
+```powershell
+Install-Module -Name monkey365 -Scope CurrentUser
+```
+
+Required version: 1.0.0 or later (below 2.0.0).
+
+## Azure App Registration
+
+To run assessments against a tenant, you need an Azure app registration with
+the right API permissions. This is the most involved setup step -- take it
+one piece at a time.
+
+### Create the App Registration
+
+1. Sign in to the [Azure Portal](https://portal.azure.com)
+2. Navigate to **Microsoft Entra ID** > **App registrations** > **New registration**
+3. Name it something recognizable (e.g., "GxAssessMS")
+4. Set **Supported account types** to "Accounts in this organizational directory only"
+5. Leave **Redirect URI** blank (not needed for client credentials)
+6. Click **Register**
+7. Copy the **Application (client) ID** and **Directory (tenant) ID** -- you'll need
+   these for your config file
+
+### Grant API Permissions
+
+The permissions you need depend on which adapters you plan to run. At minimum,
+grant these Microsoft Graph permissions (Application type):
+
+- `Directory.Read.All` -- required by most adapters
+- `Policy.Read.All` -- required for policy assessment
+- `SecurityEvents.Read.All` -- required for Secure Score
+
+For Azure-level adapters (Azure Advisor, Prowler), you also need:
+
+- **Reader** role on the Azure subscription(s) you want to assess
+
+After adding permissions, click **Grant admin consent** for the tenant.
+
+### Create a Client Secret or Certificate
+
+**Option A: Client secret** (simpler, good for testing):
+
+1. In your app registration, go to **Certificates & secrets** > **Client secrets**
+2. Click **New client secret**, set an expiry, and click **Add**
+3. Copy the secret value immediately (it won't be shown again)
+4. Store it in an environment variable:
+
+```bash
+# Linux / macOS
+export AZURE_CLIENT_SECRET="your-secret-value"  # pragma: allowlist secret
+
+# Windows PowerShell
+$env:AZURE_CLIENT_SECRET = "your-secret-value"  # pragma: allowlist secret
+```
+
+**Option B: Certificate** (recommended for production):
+
+1. Generate a certificate (or use an existing one)
+2. Upload the public key to **Certificates & secrets** > **Certificates**
+3. Reference the certificate path in your config file
+
+### Using az CLI Instead
+
+If you prefer the command line:
+
+```bash
+# Create the app registration
+az ad app create --display-name "GxAssessMS"
+
+# Note the appId from the output, then create a service principal
+az ad sp create --id <appId>
+
+# Add Graph API permissions
+az ad app permission add --id <appId> \
+  --api 00000003-0000-0000-c000-000000000000 \
+  --api-permissions 7ab1d382-f21e-4acd-a863-ba3e13f7da61=Role
+
+# Grant admin consent
+az ad app permission admin-consent --id <appId>
+```
+
+## Verify Your Setup
+
+Once everything is installed, validate with `mseco preflight`:
+
+```bash
+mseco preflight assessment.yaml
+```
+
+This checks:
+
+1. **Config validation** -- required fields, valid tool names, auth configuration
+2. **Prerequisite checks** -- whether each enabled tool is installed and meets
+   version requirements
+3. **Auth validation** -- whether credentials are accessible
+4. **Renderer checks** -- whether Node.js and npm packages are available for
+   report generation
+
+A passing preflight looks like:
+
+```
+                          Preflight Validation
+┏━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check        ┃ Status ┃ Details                                    ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ScubaGear    │  PASS  │ ScubaGear: all packages available          │
+│ SecureScore  │  PASS  │ SecureScore: all packages available        │
+└──────────────┴────────┴───────────────────────────────────────────┘
+```
+
+If a check fails, the **Details** column tells you what's missing and how to fix it.
+
+## Container Deployment
+
+> This section will be expanded as container deployment is tested in production.
+
+A minimal Dockerfile:
+
+```dockerfile
+FROM python:3.12-slim
+
+# Install PowerShell (for PS-based adapters)
+RUN apt-get update && apt-get install -y wget apt-transport-https \
+    && wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update && apt-get install -y powershell \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (for report rendering)
+RUN apt-get update && apt-get install -y nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install gxassessms
+
+ENTRYPOINT ["mseco"]
+```
+
+## Troubleshooting
+
+**"Python was not found" or wrong version:**
+
+```bash
+python3 --version   # Should be 3.12+
+```
+
+If your system has an older Python, install 3.12+ alongside it. Use `python3.12`
+explicitly or set up pyenv to manage versions.
+
+**PowerShell execution policy errors:**
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+**Module provenance verification failures:**
+
+If `mseco adapters check` shows provenance failures, the installed module version
+may not match what the adapter expects. Check the required version ranges above
+and update with `Update-Module`.
+
+**Auth errors during preflight:**
+
+- Verify your environment variable is set: `echo $AZURE_CLIENT_SECRET`
+- Confirm the app registration has the required API permissions
+- Make sure admin consent has been granted
+- Check that `client.tenant_id` and `auth.tenant_id` match in your config

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,6 +31,7 @@ auth:
 tools:
   scubagear:
     enabled: true
+    output_dir: "./output/scubagear"  # Where raw output is written
     modules: ["AAD", "EXO"]    # Start small -- just Entra ID and Exchange
     timeout: 1200              # 20 minutes (generous for a first run)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,113 @@
+# Quick Start Tutorial
+
+This tutorial walks you through running your first M365 security assessment.
+You'll configure a single tool (ScubaGear), run it against a tenant, and look
+at the results.
+
+**Time:** About 15 minutes (plus tool execution time).
+
+**Prerequisites:** Python 3.12+ installed, Azure app registration created,
+ScubaGear PowerShell module installed. See [Installation](installation.md) if
+you haven't done these yet.
+
+## 1. Create Your Config File
+
+Create a file called `assessment.yaml`:
+
+```yaml
+# Client identification
+client:
+  name: "My Company"                              # Your organization's name
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # Your M365 tenant ID
+
+# Azure authentication
+auth:
+  method: "client_credential"                     # Automated (no browser popup)
+  tenant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # Must match client.tenant_id
+  client_id: "11111111-2222-3333-4444-555555555555"   # From your app registration
+  client_secret_env: "AZURE_CLIENT_SECRET"        # pragma: allowlist secret
+
+# Which tools to run
+tools:
+  scubagear:
+    enabled: true
+    modules: ["AAD", "EXO"]    # Start small -- just Entra ID and Exchange
+    timeout: 1200              # 20 minutes (generous for a first run)
+```
+
+Replace the tenant ID and client ID with your actual values. Make sure the
+`AZURE_CLIENT_SECRET` environment variable is set.
+
+## 2. Validate Before Running
+
+Always run preflight first:
+
+```bash
+mseco preflight assessment.yaml
+```
+
+You should see something like:
+
+```
+                          Preflight Validation
+┏━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check        ┃ Status ┃ Details                                    ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ScubaGear    │  PASS  │ ScubaGear: all packages available          │
+└──────────────┴────────┴───────────────────────────────────────────┘
+```
+
+**If a check fails:**
+- **"provenance verification: no_candidates"** -- ScubaGear isn't installed or the
+  version doesn't match. Install or update it (see [Installation](installation.md)).
+- **Config validation errors** -- check that tenant IDs match and required fields
+  aren't empty. See [Configuration Reference](configuration.md) for field details.
+
+## 3. Run the Assessment
+
+```bash
+mseco run assessment.yaml
+```
+
+The pipeline runs through these stages:
+
+1. **COLLECT** -- runs ScubaGear against your tenant (this is the slow part --
+   a few minutes depending on tenant size)
+2. **PARSE** -- reads ScubaGear's raw output files
+3. **NORMALIZE** -- maps findings to the unified schema (severity, category,
+   remediation phase)
+4. **CONSOLIDATE** -- deduplicates findings (relevant when multiple tools are
+   enabled)
+5. **RENDER** -- generates the assessment report
+
+You'll see progress in the terminal. If something goes wrong, the error message
+tells you which stage failed and why.
+
+## 4. Find Your Results
+
+After a successful run, `mseco` tells you the engagement ID. You can also list
+engagements:
+
+```bash
+mseco engagement list
+```
+
+The engagement directory contains:
+
+- **Raw tool output** -- the original files from ScubaGear
+- **SQLite database** -- all findings, metadata, and pipeline events
+- **Report** -- the generated .docx file
+
+Use `mseco engagement status <engagement_id>` to see details about a specific
+engagement.
+
+## 5. Next Steps
+
+Now that you have a working assessment:
+
+- **Add more tools:** Enable `maester`, `securescore`, or others in your config.
+  See [Adapter Guide](adapters.md) for what each tool covers and how to set it up.
+- **Customize the config:** Adjust timeouts, modules, report format. See
+  [Configuration Reference](configuration.md).
+- **Explore the CLI:** `mseco replay` re-runs the pipeline from saved output,
+  `mseco report` regenerates reports. See [CLI Reference](cli-reference.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,84 @@
+# Security Model
+
+GxAssessMS is a security assessment tool that runs third-party code against
+client tenants. The security model is designed around one principle:
+**fail closed**. If something looks wrong, the pipeline stops rather than
+producing a questionable report.
+
+## Module Provenance
+
+Before running any PowerShell-based tool (ScubaGear, Maester, Monkey365),
+GxAssessMS verifies the module's integrity. This protects against supply-chain
+attacks -- someone replacing a module with a malicious version that could
+exfiltrate tenant data.
+
+The verification steps:
+
+1. **Version check** -- the installed module version must fall within the
+   adapter's allowed range (e.g., ScubaGear 1.5.0 -- 1.x)
+2. **Staging** -- the module is copied to a private temporary directory. This
+   prevents anything from modifying the module between verification and
+   execution (TOCTOU protection)
+3. **Tree hash** -- a `sha256tree:v1` hash of the entire module directory is
+   computed and compared to known-good hashes in the adapter's provenance policy
+4. **Signature verification** -- Authenticode signature is verified when the
+   module is signed; hash-only verification is used as a fallback when
+   signatures aren't available
+
+If **any** check fails, that adapter is blocked entirely. There is no
+"run anyway" option. You can see provenance status with:
+
+```bash
+mseco adapters check
+```
+
+### Narrowing the Policy
+
+The config file's `module_policy_override` lets you tighten (but never loosen)
+the provenance policy for a specific tool. For example, pinning to an exact
+version:
+
+```yaml
+tools:
+  scubagear:
+    enabled: true
+    module_policy_override:
+      version_range: "==1.5.2"
+```
+
+See [Configuration Reference](configuration.md) for the full override syntax.
+
+## Data Handling
+
+Assessment output contains sensitive tenant configuration data. GxAssessMS
+handles it carefully:
+
+- **Engagement directories** are created with `0o700` permissions (owner-only
+  access)
+- **Files** are written with `0o600` permissions
+- **All data stays local** -- nothing is sent to external services. The tool
+  does not phone home.
+- **SQLite database** uses WAL mode for safe concurrent access
+
+Data is organized per-engagement. Each engagement has its own directory
+containing raw tool output, the SQLite database, and generated reports.
+
+## Config Security
+
+- **Secrets are never stored in the config file.** The `client_secret_env` field
+  holds the *name* of an environment variable, not the secret itself. This means
+  config files can be committed to version control without exposing credentials.
+- **Strict validation** rejects unknown fields, wrong types, and malformed values
+  immediately. No input is silently coerced.
+- **No string substitution** in PowerShell execution. Tool arguments are passed
+  through structured JSON, eliminating injection vectors.
+
+## Operator Checklist
+
+- Keep PowerShell modules up to date within the adapter's supported version range
+- Use `client_credential` with a certificate for production assessments (more
+  secure than a client secret)
+- Rotate client secrets regularly
+- Review assessment output before sharing it with anyone outside the engagement
+- Clean up completed engagements with `mseco engagement purge --confirm <id>`
+  when the data is no longer needed

--- a/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
@@ -65,8 +65,8 @@ in under 2 minutes.
    - Produces a single report
    - Emphasize: you don't need to know how each tool works individually
 
-3. **Quick install.** `pip install gxassessms` (or editable install for now). Python 3.14+
-   called out prominently with a note about why.
+3. **Quick install.** `pip install gxassessms` (or editable install for now). Python 3.12+
+   requirement noted.
 
 4. **Minimal example.** ~15-line config YAML (client name, tenant ID, auth, one tool) +
    `mseco run config.yaml`. Show what happens, what output to expect.
@@ -88,13 +88,13 @@ Highest-traffic page for IT admins who've never touched Python.
 
 **Structure:**
 
-1. **Requirements summary.** Table: Python 3.14+, PowerShell 7+ (for PS-based adapters),
+1. **Requirements summary.** Table: Python 3.12+, PowerShell 7+ (for PS-based adapters),
    Node.js (for report rendering). Clear about what's optional per adapter type.
 
-2. **Python 3.14.** Biggest friction point. Short explanation of why, then
-   platform-specific instructions:
-   - Windows: python.org download, winget, pyenv-win
-   - Linux: deadsnakes PPA, pyenv
+2. **Python setup.** 3.12+ is widely available on all platforms. Brief
+   platform-specific pointers:
+   - Windows: python.org download or winget
+   - Linux: system package manager or deadsnakes PPA
    - Container: base image recommendation
 
 3. **Installing gxassessms.** `pip install gxassessms` and editable install from source.

--- a/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
@@ -157,8 +157,8 @@ Full config YAML reference. Operators come here after the quickstart.
    `pipeline`), only `client` and `auth` required. Note: strict validation rejects
    misspelled keys and wrong types immediately.
 
-2. **`client` section.** Field table: `name` (required), `tenant_id` (required),
-   `subscription_id` (optional). Must match auth.tenant_id.
+2. **`client` section.** Field table: `name` (required), `tenant_id` (required,
+   must match `auth.tenant_id`), `subscription_id` (optional).
 
 3. **`auth` section.** Four auth methods explained separately:
    - `client_credential` with secret (automated/unattended)
@@ -177,8 +177,9 @@ Full config YAML reference. Operators come here after the quickstart.
 6. **`pipeline` section.** `max_parallel`, `qa_model`, `qa_token_budget`. Trade-off
    guidance.
 
-7. **Module provenance overrides.** What `module_policy_override` does (exact
-   version/hash pin). Link to security.md. Framed as advanced.
+7. **Module provenance overrides.** Clarify this is a per-tool nested field within
+   the `tools` section, not a top-level config section. What `module_policy_override`
+   does (exact version/hash pin). Link to security.md. Framed as advanced.
 
 8. **Complete example.** Full annotated YAML showing all sections. Copy-paste starting
    point.
@@ -203,10 +204,11 @@ Scannable reference. No prose paragraphs -- syntax, examples, notes.
    - `mseco replay` -- re-run from raw outputs
    - `mseco consolidate` -- re-consolidate with different policy
    - `mseco review` -- QA review workflow
-   - `mseco engagement list|status|archive|export|delete` -- lifecycle
+   - `mseco engagement create|list|status|archive|restore|purge|export` -- lifecycle
    - `mseco adapters list|check|scaffold` -- discovery
    - `mseco ingest` -- import external output
    - `mseco compute-module-hash` -- advanced/security
+   - `mseco analytics` -- tracking and trends (extension point)
 
    Each subsection: what it does (one sentence), syntax + options, example
    invocation, expected output/exit codes/common errors.
@@ -273,7 +275,7 @@ Operator-facing trust model. Not the internal threat model.
 
 5. **Operator checklist.** Keep modules updated, use certificate auth for production,
    rotate secrets, review output before sharing, clean up with
-   `mseco engagement delete`.
+   `mseco engagement purge`.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
@@ -1,0 +1,317 @@
+# User-Facing Documentation Design
+
+**Date:** 2026-04-13
+**Scope:** Both repos (gxassessms + gxassessms-guardantix)
+**Audiences:** (a) Non-expert IT admin operators (public package), (d) Internal Guardantix developers (private package)
+
+## Design Principles
+
+- Target audience is an IT admin who is not a security expert. They know their M365
+  tenant but may not know what ScubaGear is or how Azure app registrations work.
+- Foundation-first: document what works today, structured for expansion as features
+  mature through real client engagements.
+- The README is the front door. Docs/ pages are the rooms. No one should have to read
+  the architecture spec to run an assessment.
+
+---
+
+## File Layout
+
+New user-facing docs go at the top level of `docs/`. Existing internal docs stay
+where they are:
+
+```
+gxassessms/
+  README.md                              # rewrite
+  docs/
+    installation.md                      # new
+    quickstart.md                        # new
+    configuration.md                     # new
+    cli-reference.md                     # new
+    adapters.md                          # new
+    security.md                          # new (operator-facing)
+    runbook.md                           # existing, unchanged
+    security/                            # existing internal docs, unchanged
+      gxassessms-threat-model.md
+      gxassessms-security-best-practices-report.md
+      shared-host-deployment.md
+    superpowers/specs/                   # existing design specs, unchanged
+    superpowers/plans/                   # existing plans, unchanged
+
+gxassessms-guardantix/
+  README.md                              # rewrite
+  (all other docs unchanged)
+```
+
+---
+
+## Public Package: gxassessms
+
+### 1. README.md (complete rewrite)
+
+Replaces the current stub. Answers "what is this, why should I care, how do I start"
+in under 2 minutes.
+
+**Structure:**
+
+1. **Title + one-liner.** "Microsoft Ecosystem Assessment Orchestrator." Plain English:
+   runs security/compliance tools against your M365 tenant and consolidates results
+   into a single report.
+
+2. **What it does.** 3-4 bullet points, no jargon:
+   - Runs ScubaGear, Maester, Monkey365, and other tools for you
+   - Consolidates overlapping findings and deduplicates
+   - Assigns severity and remediation priority
+   - Produces a single report
+   - Emphasize: you don't need to know how each tool works individually
+
+3. **Quick install.** `pip install gxassessms` (or editable install for now). Python 3.14+
+   called out prominently with a note about why.
+
+4. **Minimal example.** ~15-line config YAML (client name, tenant ID, auth, one tool) +
+   `mseco run config.yaml`. Show what happens, what output to expect.
+
+5. **Documentation links.** Table pointing to each doc in `docs/`.
+
+6. **Supported tools.** Adapter table with one-line descriptions (carried forward from
+   current README).
+
+7. **License.** MIT.
+
+**Removes from current README:** Architecture ASCII diagram (moves to internal docs),
+module provenance details (moves to docs/security.md), CLI command listing (moves to
+docs/cli-reference.md).
+
+### 2. docs/installation.md
+
+Highest-traffic page for IT admins who've never touched Python.
+
+**Structure:**
+
+1. **Requirements summary.** Table: Python 3.14+, PowerShell 7+ (for PS-based adapters),
+   Node.js (for report rendering). Clear about what's optional per adapter type.
+
+2. **Python 3.14.** Biggest friction point. Short explanation of why, then
+   platform-specific instructions:
+   - Windows: python.org download, winget, pyenv-win
+   - Linux: deadsnakes PPA, pyenv
+   - Container: base image recommendation
+
+3. **Installing gxassessms.** `pip install gxassessms` and editable install from source.
+   Virtual environment setup.
+
+4. **PowerShell modules.** Per-module: `Install-Module` commands, version requirements.
+   Note that `mseco` verifies module integrity (link to security.md).
+
+5. **Azure app registration.** Step-by-step: create registration, grant API permissions
+   (per adapter), generate secret or certificate. Exact portal navigation paths and
+   az CLI equivalents. This is the highest-friction section for non-experts.
+
+6. **Verify installation.** `mseco preflight config.yaml` as smoke test. Explain each
+   check and what to do if one fails.
+
+7. **Container deployment.** Placeholder section -- Dockerfile sketch, expand when
+   battle-tested.
+
+8. **Troubleshooting.** Common problems: wrong Python version, PowerShell execution
+   policy, module not found, auth permission errors.
+
+### 3. docs/quickstart.md
+
+Complete tutorial: "I just installed this" to "I'm looking at my first report."
+
+**Structure:**
+
+1. **What you'll do.** One paragraph: configure a single-adapter assessment (ScubaGear),
+   run it, look at the output. ~15 minutes, requires a working Azure app registration
+   (links to installation.md).
+
+2. **Create your config file.** Annotated minimal YAML with inline comments. Client
+   name, tenant ID, auth with `client_credential`, ScubaGear enabled with a few
+   modules (`aad`, `exo`).
+
+3. **Validate before running.** `mseco preflight config.yaml`. Walk through each line
+   of output, what "OK" means, what failure looks like, what to fix.
+
+4. **Run the assessment.** `mseco run config.yaml`. Explain each stage (COLLECT, PARSE,
+   NORMALIZE, CONSOLIDATE, RENDER) in plain language. Set expectations for timing
+   (~5-15 minutes depending on tenant size).
+
+5. **Understand the output.** Where the engagement directory is, what files are in it,
+   how to read the report. Walk through example findings: severity, remediation
+   recommendation.
+
+6. **Next steps.** Enable more adapters, customize report options, `mseco engagement
+   list`. Links to configuration.md and cli-reference.md.
+
+Deliberately stops before QA review, analytics, or anything requiring the private
+package. Self-contained "first win" with just the public package.
+
+### 4. docs/configuration.md
+
+Full config YAML reference. Operators come here after the quickstart.
+
+**Structure:**
+
+1. **Config file overview.** Five top-level sections (`client`, `auth`, `tools`, `report`,
+   `pipeline`), only `client` and `auth` required. Note: strict validation rejects
+   misspelled keys and wrong types immediately.
+
+2. **`client` section.** Field table: `name` (required), `tenant_id` (required),
+   `subscription_id` (optional). Must match auth.tenant_id.
+
+3. **`auth` section.** Four auth methods explained separately:
+   - `client_credential` with secret (automated/unattended)
+   - `client_credential` with certificate (higher security)
+   - `device_code` (interactive, admin at keyboard)
+   - `interactive` (browser-based)
+   Each: when to use, required fields, example YAML. Emphasize `client_secret_env`
+   is env var *name*, not the secret.
+
+4. **`tools` section.** Shorthand (`scubagear: true`) vs expanded form. ToolConfig
+   field table. Per-adapter subsections with valid `modules`, recommended timeouts,
+   useful `extra_args`. Link to adapters.md.
+
+5. **`report` section.** Formats, themes, logo. Note which are built-in vs extension.
+
+6. **`pipeline` section.** `max_parallel`, `qa_model`, `qa_token_budget`. Trade-off
+   guidance.
+
+7. **Module provenance overrides.** What `module_policy_override` does (exact
+   version/hash pin). Link to security.md. Framed as advanced.
+
+8. **Complete example.** Full annotated YAML showing all sections. Copy-paste starting
+   point.
+
+9. **Validation errors.** Table of every error/warning from `mseco preflight`, cause,
+   and fix.
+
+### 5. docs/cli-reference.md
+
+Scannable reference. No prose paragraphs -- syntax, examples, notes.
+
+**Structure:**
+
+1. **Global options.** `--log-level`, `--log-format`, `-v/--verbose`. When to use JSON
+   vs Rich logging.
+
+2. **One subsection per command**, ordered by frequency of use:
+   - `mseco run` -- full pipeline
+   - `mseco preflight` -- validation
+   - `mseco collect` -- collection only
+   - `mseco report` -- regenerate from existing data
+   - `mseco replay` -- re-run from raw outputs
+   - `mseco consolidate` -- re-consolidate with different policy
+   - `mseco review` -- QA review workflow
+   - `mseco engagement list|status|archive|export|delete` -- lifecycle
+   - `mseco adapters list|check|scaffold` -- discovery
+   - `mseco ingest` -- import external output
+   - `mseco compute-module-hash` -- advanced/security
+
+   Each subsection: what it does (one sentence), syntax + options, example
+   invocation, expected output/exit codes/common errors.
+
+3. **Common workflows.** Short recipes:
+   - Full assessment: `preflight` then `run`
+   - Re-generate report: `report`
+   - Resume after failure: `replay`
+   - Check installation: `adapters list` + `adapters check`
+
+### 6. docs/adapters.md
+
+Per-adapter reference for operators choosing which tools to enable.
+
+**Structure:**
+
+1. **Overview.** What adapters are, how they're discovered, that failures in one don't
+   block others.
+
+2. **One subsection per adapter**, ordered by likely use:
+   - **ScubaGear** -- CISA SCuBA M365 baseline
+   - **Maester** -- Entra ID / M365 security testing
+   - **Monkey365** -- Azure / M365 / Entra ID compliance
+   - **Prowler** -- multi-cloud security (Azure focus)
+   - **Secure Score** -- Microsoft's built-in scoring (API-based)
+   - **Azure Advisor** -- Azure recommendations (API-based)
+   - **M365 Assess** -- custom M365 assessment framework
+
+   Each: what it assesses (plain language), requirements (module/API permissions),
+   config options (valid `modules`, recommended timeout, useful `extra_args`),
+   coverage (which services, which frameworks), known quirks.
+
+3. **Choosing which adapters to run.** Decision guidance:
+   - M365 only: ScubaGear + Maester
+   - Add Azure: + Monkey365
+   - Lightweight extras: Secure Score + Azure Advisor
+   - Simple decision matrix, not "figure it out yourself"
+
+4. **How findings overlap.** Brief: multiple tools may flag the same issue,
+   consolidation engine deduplicates. Operator doesn't need to worry.
+
+### 7. docs/security.md
+
+Operator-facing trust model. Not the internal threat model.
+
+**Structure:**
+
+1. **Security philosophy.** Fail-closed. If something looks wrong, the pipeline stops.
+   A security assessment tool that silently swallows errors is worse than useless.
+
+2. **Module provenance.** Plain-language explanation:
+   - Version checked against adapter's pinned range
+   - Module copied to private temp dir (nothing can change it mid-run)
+   - Tree hash computed and compared to known-good hashes
+   - Authenticode signature verified when available
+   - Any check failure blocks that adapter entirely
+   Framed as supply-chain protection.
+
+3. **Data handling.** Where data lives (engagement dir, SQLite DB), permissions set
+   (0o700 dirs, 0o600 files), nothing phones home.
+
+4. **Config security.** Secrets by env var name only. Strict validation prevents
+   injection via malformed values.
+
+5. **Operator checklist.** Keep modules updated, use certificate auth for production,
+   rotate secrets, review output before sharing, clean up with
+   `mseco engagement delete`.
+
+---
+
+## Private Package: gxassessms-guardantix
+
+### README.md (rewrite as internal onboarding guide)
+
+**Structure:**
+
+1. **What this is.** One paragraph: proprietary extension. AI QA, branded reports,
+   review UI, analytics, longitudinal tracking. Discovered via entry points.
+
+2. **Relationship to gxassessms.** Dependency rule, how entry points work, which
+   Protocols this package implements. 30-second understanding of the boundary.
+
+3. **Development setup.** Step-by-step:
+   - Clone both repos into workspace
+   - Run `scripts/setup-venv.sh`
+   - Verify: `pytest` and `mseco adapters list`
+   - Note: Anthropic API key needed for QA layer development
+
+4. **Package layout.** Five modules (qa, reporting, review_ui, analytics, longitudinal)
+   with one sentence each. Not an architecture repeat -- just where to look.
+
+5. **Key documentation.** Table: architecture spec, code conventions, build log,
+   roadmap, CHANGELOG. With guidance on when to read each.
+
+6. **Testing.** How to run (`pytest`), test layers (unit, integration, contracts,
+   conventions), coverage expectations.
+
+7. **Entry points.** Table: QA strategy, renderers (docx, pptx), analytics, review UI.
+   Makes "extends via entry points" concrete.
+
+---
+
+## Out of Scope (deferred)
+
+- Contributor guide / CONTRIBUTING.md (audience b/c)
+- Adapter authoring guide (audience b)
+- API/extension documentation (audience b)
+- Deployment deep dives (container, CI) beyond placeholder sections

--- a/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-facing-documentation-design.md
@@ -1,8 +1,8 @@
 # User-Facing Documentation Design
 
 **Date:** 2026-04-13
-**Scope:** Both repos (gxassessms + gxassessms-guardantix)
-**Audiences:** (a) Non-expert IT admin operators (public package), (d) Internal Guardantix developers (private package)
+**Scope:** gxassessms (public package)
+**Audience:** Non-expert IT admin operators
 
 ## Design Principles
 
@@ -37,10 +37,6 @@ gxassessms/
       shared-host-deployment.md
     superpowers/specs/                   # existing design specs, unchanged
     superpowers/plans/                   # existing plans, unchanged
-
-gxassessms-guardantix/
-  README.md                              # rewrite
-  (all other docs unchanged)
 ```
 
 ---
@@ -144,8 +140,7 @@ Complete tutorial: "I just installed this" to "I'm looking at my first report."
 6. **Next steps.** Enable more adapters, customize report options, `mseco engagement
    list`. Links to configuration.md and cli-reference.md.
 
-Deliberately stops before QA review, analytics, or anything requiring the private
-package. Self-contained "first win" with just the public package.
+Self-contained "first win" with just the base package.
 
 ### 4. docs/configuration.md
 
@@ -279,41 +274,9 @@ Operator-facing trust model. Not the internal threat model.
 
 ---
 
-## Private Package: gxassessms-guardantix
-
-### README.md (rewrite as internal onboarding guide)
-
-**Structure:**
-
-1. **What this is.** One paragraph: proprietary extension. AI QA, branded reports,
-   review UI, analytics, longitudinal tracking. Discovered via entry points.
-
-2. **Relationship to gxassessms.** Dependency rule, how entry points work, which
-   Protocols this package implements. 30-second understanding of the boundary.
-
-3. **Development setup.** Step-by-step:
-   - Clone both repos into workspace
-   - Run `scripts/setup-venv.sh`
-   - Verify: `pytest` and `mseco adapters list`
-   - Note: Anthropic API key needed for QA layer development
-
-4. **Package layout.** Five modules (qa, reporting, review_ui, analytics, longitudinal)
-   with one sentence each. Not an architecture repeat -- just where to look.
-
-5. **Key documentation.** Table: architecture spec, code conventions, build log,
-   roadmap, CHANGELOG. With guidance on when to read each.
-
-6. **Testing.** How to run (`pytest`), test layers (unit, integration, contracts,
-   conventions), coverage expectations.
-
-7. **Entry points.** Table: QA strategy, renderers (docx, pptx), analytics, review UI.
-   Makes "extends via entry points" concrete.
-
----
-
 ## Out of Scope (deferred)
 
-- Contributor guide / CONTRIBUTING.md (audience b/c)
-- Adapter authoring guide (audience b)
-- API/extension documentation (audience b)
+- Contributor guide / CONTRIBUTING.md
+- Adapter authoring guide
+- API/extension documentation
 - Deployment deep dives (container, CI) beyond placeholder sections


### PR DESCRIPTION
## Summary

- Rewrites README.md for operator audience (non-expert IT admins running M365 assessments)
- Adds six new docs: installation guide, quick start tutorial, configuration reference, CLI reference, adapter guide, and security model
- Documents required `script_dir`/`output_dir` fields for M365 Assess adapter

All seven public docs are written for operators with no prior GxAssessMS experience. No private package details are referenced.

## Test plan

- [ ] Verify all cross-document links resolve (README -> docs/*.md)
- [ ] Verify config examples parse as valid YAML
- [ ] Verify CLI command names and options match `mseco --help` output
- [ ] Verify adapter version ranges match `adapters/*/policy.py`
- [ ] Verify no boundary violations (no Guardantix/AI QA/branded/Anthropic references)