### PR TITLE
docs: add architecture, pipeline, data-model, extension-points

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,9 +112,10 @@ flowchart TB
     qa --> contracts
 ```
 
-**Dependency direction.** `core/domain/` has no internal imports;
-`core/contracts/` imports only from `domain/`; everything else builds on top.
-This is enforced by the import-boundary convention tests
+**Dependency direction.** `core/domain/` and `core/config/` have no imports
+from other project packages; `core/contracts/` imports only from `domain/`
+and `config/`; everything else builds on top. This is enforced by the
+import-boundary convention tests
 (`tests/conventions/test_import_boundaries.py`).
 
 ### What each layer does

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,306 @@
+# Architecture Overview
+
+GxAssessMS is a pipeline-oriented orchestrator for Microsoft 365 / Azure
+assessment tools. It discovers tool adapters at startup, runs them in
+parallel, parses and normalizes their output into a unified domain model,
+deduplicates findings across tools, and renders a report.
+
+This document describes the public framework: the layers, the data that flows
+between them, and the Protocol-based extension points that let new tools,
+renderers, policies, and QA strategies plug in without forking the package.
+
+Detailed Protocol signatures live in [extension-points.md](extension-points.md).
+Pipeline lifecycle, plugin discovery, and consolidation diagrams are in
+[pipeline.md](pipeline.md) and [data-model.md](data-model.md).
+
+## Layers
+
+```mermaid
+flowchart TB
+    subgraph cli["cli/"]
+        cli_main["main.py"]
+        cli_cmds["commands/<br/>(run, collect, consolidate,<br/>report, replay, ingest,<br/>preflight, engagement,<br/>adapters, analytics, review)"]
+        cli_helpers["_helpers.py<br/>(orchestrator factory,<br/>plugin discovery)"]
+    end
+
+    subgraph pipeline["pipeline/"]
+        orch["orchestrator.py<br/>Orchestrator"]
+        runner["_runner.py<br/>run_stages, StageContext"]
+        stages["stages.py<br/>Stage enum, stage fns"]
+        state["state.py<br/>EngagementLock,<br/>PipelineEvent"]
+        replay["replay.py<br/>load_raw_outputs"]
+        confine["confinement.py<br/>confine_and_resolve"]
+    end
+
+    subgraph adapters["adapters/"]
+        adapter_reg["__init__.py<br/>discover_adapters"]
+        adapter_pkgs["scubagear/ maester/<br/>monkey365/ m365_assess/<br/>prowler/ secure_score/<br/>azure_advisor/"]
+    end
+
+    subgraph policy["policy/"]
+        norm["normalization.py"]
+        cons["consolidation.py"]
+        sev["severity.py"]
+        road["roadmap.py"]
+        rep_pol["reporting.py"]
+    end
+
+    subgraph consolidation["consolidation/"]
+        dedup["dedup.py<br/>UnionFindDedup"]
+        rules["rules.py<br/>DefaultConsolidationRule"]
+    end
+
+    subgraph persistence["persistence/"]
+        db["database.py<br/>SQLite WAL,<br/>migrations"]
+        repos["EngagementRepo<br/>FindingRepo<br/>CoverageRepo<br/>EventRepo"]
+        artifacts["artifacts.py<br/>ArtifactManager"]
+    end
+
+    subgraph reporting["reporting/"]
+        payload["payload.py<br/>assemble_payload"]
+        rr["renderer_registry.py<br/>RendererRegistry,<br/>NodeRenderer"]
+        basic["basic_renderer.py"]
+    end
+
+    subgraph core["core/"]
+        domain["domain/<br/>enums, models,<br/>constants"]
+        contracts["contracts/<br/>types (Protocols),<br/>errors, credentials"]
+        config["config/<br/>EngagementConfig,<br/>datetime_utils"]
+        security["security/<br/>permissions,<br/>audit_context"]
+    end
+
+    qa["qa/<br/>NoOpQAStrategy"]
+    registry["registry.py<br/>discover_entry_points"]
+
+    cli_main --> cli_cmds
+    cli_cmds --> cli_helpers
+    cli_helpers --> orch
+    cli_helpers --> adapter_reg
+    cli_helpers --> rr
+    cli_helpers --> qa
+    cli_helpers --> policy
+
+    orch --> runner
+    runner --> stages
+    runner --> repos
+    runner --> artifacts
+    runner --> confine
+    stages --> adapter_pkgs
+    stages --> policy
+    stages --> consolidation
+    stages --> qa
+    stages --> reporting
+
+    adapter_reg --> registry
+    rr --> registry
+
+    rules --> dedup
+    rules --> cons
+
+    repos --> db
+    artifacts --> db
+
+    payload --> repos
+    rr --> basic
+
+    pipeline --> contracts
+    adapters --> contracts
+    policy --> contracts
+    consolidation --> contracts
+    reporting --> contracts
+    persistence --> contracts
+    qa --> contracts
+```
+
+**Dependency direction.** `core/domain/` has no internal imports;
+`core/contracts/` imports only from `domain/`; everything else builds on top.
+This is enforced by the import-boundary convention tests
+(`tests/conventions/test_import_boundaries.py`).
+
+### What each layer does
+
+- **`core/`** -- domain types, Protocols, errors, config, and security
+  primitives. No I/O at import time. Defines the contract that the rest of
+  the package, and any extension package, builds against.
+- **`adapters/`** -- one package per tool (ScubaGear, Maester, Monkey365,
+  M365-Assess, Prowler, Secure Score, Azure Advisor). Each implements the
+  `ToolAdapter` Protocol with `adapter.py`, `parser.py`, `mappings.py`, plus
+  fixtures. The registry under `adapters/__init__.py` discovers and validates
+  them from entry points.
+- **`pipeline/`** -- the orchestrator, stage functions, state machine,
+  advisory locking, and the append-only event journal. Stages are pure
+  functions that take inputs and return outputs; the orchestrator wires them
+  together and persists results between stages.
+- **`policy/`** -- judgment isolated from execution. Normalization, dedup
+  reconciliation, severity overrides, roadmap phase assignment, and report
+  suppression each live in their own module. Policy modules never do I/O;
+  YAML rule data is loaded by `core/config/` and injected as plain dicts.
+- **`consolidation/`** -- the union-find dedup engine and the default
+  `ConsolidationRule` that bridges dedup grouping with the policy-driven
+  merge step.
+- **`persistence/`** -- SQLite with WAL mode plus per-engagement directories
+  on disk. Repository classes are the only callers of SQL. Raw tool output
+  lives on the filesystem; structured derivatives live in the DB.
+- **`reporting/`** -- builds a `ReportPayload`, then hands it to one or more
+  registered renderers. Renderers are Python wrappers over Node.js packages
+  invoked via `NodeRenderer`.
+- **`cli/`** -- Click-based commands. Each command is a thin wrapper: load
+  config, build the orchestrator, call it. No business logic.
+- **`qa/`** -- ships a `NoOpQAStrategy` that auto-advances `QA_REVIEW -> QA_APPROVED`.
+  Replacement strategies register through the `gxassessms.qa_strategies`
+  entry-point group.
+- **`registry.py`** -- generic entry-point discovery. The adapter registry
+  (`adapters/__init__.py`) and renderer registry
+  (`reporting/renderer_registry.py`) both build on it.
+
+## Extension Points
+
+Every customization seam in the framework is a Protocol declared in
+[`core/contracts/types.py`](../src/gxassessms/core/contracts/types.py) or, for
+credentials, [`core/contracts/credentials.py`](../src/gxassessms/core/contracts/credentials.py).
+Implementations are discovered via `importlib.metadata` entry points.
+
+| Protocol | Entry-point group | Default implementation |
+|----------|-------------------|------------------------|
+| `ToolAdapter` | `gxassessms.adapters` | Seven adapters in `gxassessms.adapters.*` |
+| `IngestCapableAdapter` | `gxassessms.adapters` | Adapters declaring `"ingest"` capability |
+| `ReportRenderer` | `gxassessms.renderers` | `BasicDocxRenderer` (`basic_docx`) |
+| `QAStrategy` | `gxassessms.qa_strategies` | `NoOpQAStrategy` (`noop`) |
+| `ConsolidationRule` | `gxassessms.consolidation_rules` | `DefaultConsolidationRule` (`default`) |
+| `NormalizationPolicy` | `gxassessms.policies` (`normalization`) | `DefaultNormalizationPolicy` |
+| `ConsolidationPolicy` | `gxassessms.policies` (`consolidation`) | `DefaultConsolidationPolicy` |
+| `CredentialProvider` | `gxassessms.credentials` | `EnvVarProvider` (`env_var`) |
+
+Additional optional groups -- `gxassessms.analytics`, `gxassessms.review_ui` --
+are checked by the CLI; commands that depend on them print a clear message
+when no implementation is registered (see
+[cli-reference.md](cli-reference.md#mseco-analytics)).
+
+See [extension-points.md](extension-points.md) for method signatures, return
+shapes, and contract semantics.
+
+## Data Model at a Glance
+
+The full ER diagram is in [data-model.md](data-model.md). The short version:
+
+```mermaid
+flowchart LR
+    rt[RawToolOutput<br/>+ ResolvedManifest] --> obs[ToolObservation]
+    obs --> finding[Finding]
+    finding --> cf[ConsolidatedFinding]
+    cf --> payload[ReportPayload]
+
+    cov[CoverageRecord] --> payload
+    auth[AuthContext] -. used by .-> rt
+    trr[ToolRunResult] -. metadata for .-> rt
+
+    classDef raw fill:#fef3c7,stroke:#92400e
+    classDef domain fill:#dbeafe,stroke:#1e40af
+    classDef report fill:#dcfce7,stroke:#166534
+    class rt,obs raw
+    class finding,cf,cov domain
+    class payload report
+```
+
+Three explicit finding identities track different concerns:
+
+- `observation_id` -- tool-native parse-level identity
+  (`{tool}:{native_check_id}`), assigned by `parse()`
+- `finding_key` -- normalized semantic identity for dedup and stable
+  cross-assessment comparison (e.g., `cis:m365:5.2.2.1`), assigned by the
+  normalization policy
+- `finding_instance_id` -- engagement-specific UUID, assigned when a
+  `ConsolidatedFinding` is created in the DB; never reused across engagements
+
+## Pipeline Lifecycle
+
+```mermaid
+flowchart LR
+    CREATED --> COLLECTING --> COLLECTED
+    COLLECTED --> PARSING --> PARSED
+    PARSED --> NORMALIZING --> NORMALIZED
+    NORMALIZED --> CONSOLIDATING --> CONSOLIDATED
+    CONSOLIDATED --> QA_REVIEW --> QA_APPROVED
+    QA_APPROVED --> RENDERING --> COMPLETE
+
+    CREATED -. failure .-> FAILED
+    COLLECTING -. failure .-> FAILED
+    PARSING -. failure .-> FAILED
+    NORMALIZING -. failure .-> FAILED
+    CONSOLIDATING -. failure .-> FAILED
+    QA_REVIEW -. failure .-> FAILED
+    RENDERING -. failure .-> FAILED
+```
+
+Valid transitions are defined as a frozen mapping in
+[`core/domain/enums.py:113-152`](../src/gxassessms/core/domain/enums.py) and
+enforced by `EngagementState.assert_can_transition_to()`. The orchestrator
+records every transition as a `state_transition` event in the journal; stage
+state is a materialized projection of the journal.
+
+See [pipeline.md](pipeline.md) for the full orchestrator and stage-level
+sequence diagrams.
+
+## Concurrency and Resilience
+
+- **Parallel collection.** `pipeline.stages.collect()` runs adapters in a
+  `ThreadPoolExecutor` (size = `config.max_parallel or len(adapters)`).
+  Failures are captured as `CollectionResult` with status `FAILED` or
+  `TIMEOUT`; the pipeline continues with partial results.
+  ([stages.py:76-158](../src/gxassessms/pipeline/stages.py))
+- **Advisory locking.** The CLI and any external review interface share an
+  `EngagementLock` backed by `filelock`
+  (`<engagements_root>/.locks/<engagement_id>.lock`).
+  Mutating operations acquire the lock; concurrent attempts raise
+  `LockTimeoutError` after the configured timeout.
+  ([state.py:109-170](../src/gxassessms/pipeline/state.py))
+- **Crash recovery.** Stage transitions are persisted atomically as journal
+  events. The orchestrator detects engagements left in a `*ING` state from a
+  killed process and treats them as failed stages on the next run
+  ([orchestrator.py:350-366](../src/gxassessms/pipeline/orchestrator.py)).
+
+## Persistence
+
+- **SQLite (WAL mode).** Schema lives in
+  [`persistence/migrations/`](../src/gxassessms/persistence/migrations/); the
+  current state is captured in `001_initial.sql`. Subsequent migrations are
+  applied in order and tracked in `_schema_migrations`.
+- **Repository pattern.** No layer outside `persistence/` writes SQL. Repos
+  expose typed CRUD: `EngagementRepo`, `FindingRepo`, `CoverageRepo`,
+  `EventRepo`.
+- **Hybrid storage.** Raw tool output, generated reports, and JSON manifests
+  live under the engagement directory; structured derivatives (findings,
+  coverage, events, overrides) live in the DB. Defaults: `~/.gxassessms/`
+  for the data root, overridable via `GXASSESSMS_DATA_DIR`; DB path
+  overridable via `GXASSESSMS_DB_PATH`
+  ([database.py:25-46](../src/gxassessms/persistence/database.py)).
+
+## Security Boundary
+
+This document is about structure; the threat model and operator checklist
+live in [security.md](security.md). The architecturally relevant points:
+
+- Adapter prerequisites are checked against a code-owned `MODULE_POLICY` for
+  each PowerShell-based adapter
+  (e.g., `adapters/scubagear/policy.py`).
+- `confine_and_resolve()` validates that every adapter-produced artifact
+  path resolves inside the engagement directory; manifests that escape it
+  raise `ManifestConfinementError`.
+- Adapter raw output is structurally validated through `validate_raw()`
+  before any `parse()` call. Failures raise `RawOutputValidationError` and
+  short-circuit the parse stage.
+- Credentials are resolved through the `CredentialProvider` Protocol;
+  `AuthContext` may hold a `SecretStr` but `credential_refs` must contain
+  only lookup identifiers (validated by
+  [`models.AuthContext.credential_refs_must_be_lookup_refs`](../src/gxassessms/core/domain/models.py)).
+
+## Where to go next
+
+- **Add an adapter:** start with [extension-points.md](extension-points.md#tooladapter)
+  and the spec's adapter section.
+- **Replace a renderer:** see
+  [extension-points.md](extension-points.md#reportrenderer) and
+  `reporting/renderer_registry.py`.
+- **Understand a pipeline run:** [pipeline.md](pipeline.md).
+- **Understand the data:** [data-model.md](data-model.md).
+- **Operate the system:** [runbook.md](runbook.md).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -25,6 +25,7 @@ erDiagram
     engagements ||--o{ pipeline_events : has
     engagements ||--o{ overrides : has
     engagements ||--o{ stage_history : has
+    engagements ||--o{ longitudinal_snapshots : has
     findings ||--o{ overrides : "overridden via finding_id"
 
     engagements {
@@ -131,6 +132,22 @@ erDiagram
         REAL duration_seconds
     }
 
+    longitudinal_snapshots {
+        INTEGER id PK
+        TEXT engagement_id FK
+        TEXT snapshot_date
+        INTEGER total_findings
+        INTEGER critical_count
+        INTEGER high_count
+        INTEGER medium_count
+        INTEGER low_count
+        INTEGER info_count
+        INTEGER controls_assessed
+        INTEGER controls_not_assessed
+        TEXT findings_data "JSON snapshot"
+        TEXT created_at
+    }
+
 ```
 
 **Notes on relationships.**
@@ -165,6 +182,7 @@ Defined alongside the schema:
 | `idx_overrides_engagement` | `(engagement_id)` | override export |
 | `idx_stage_history_engagement` | `(engagement_id)` | timing analytics |
 | `idx_tool_run_results_engagement` | `(engagement_id)` | run metadata |
+| `idx_longitudinal_snapshots_engagement_date` | `(engagement_id, snapshot_date)` UNIQUE | trend-tracking snapshots |
 
 ## In-Memory Pydantic Models
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,411 @@
+# Public Data Model
+
+This document covers the persisted relational shape (SQLite) and the
+in-memory Pydantic models that flow between pipeline stages. For the
+Protocol contracts that consume and produce these models see
+[extension-points.md](extension-points.md). For pipeline flow see
+[pipeline.md](pipeline.md).
+
+## SQLite Schema (Engagement Database)
+
+Schema lives in
+[`persistence/migrations/001_initial.sql`](../src/gxassessms/persistence/migrations/001_initial.sql)
+with subsequent migrations applied in order
+([002_add_native_check_id.sql](../src/gxassessms/persistence/migrations/002_add_native_check_id.sql)).
+WAL mode is enabled on every connection; the `_schema_migrations` table
+tracks applied files
+([`database.py:115-181`](../src/gxassessms/persistence/database.py)).
+
+```mermaid
+erDiagram
+    engagements ||--o{ findings : has
+    engagements ||--o{ consolidated_findings : has
+    engagements ||--o{ coverage_records : has
+    engagements ||--o{ tool_run_results : has
+    engagements ||--o{ pipeline_events : has
+    engagements ||--o{ overrides : has
+    engagements ||--o{ stage_history : has
+    findings ||--o{ overrides : "overridden via finding_id"
+
+    engagements {
+        TEXT engagement_id PK
+        TEXT client_name
+        TEXT tenant_id
+        TEXT state "CHECK enum"
+        TEXT created_at
+        TEXT updated_at
+        TEXT config_snapshot "JSON EngagementConfig"
+        TEXT engagement_dir
+        TEXT schema_version "default 1.0.0"
+    }
+
+    findings {
+        TEXT finding_id PK
+        TEXT engagement_id FK
+        TEXT observation_id
+        TEXT finding_key
+        TEXT native_check_id
+        TEXT tool_source
+        TEXT title
+        TEXT severity "CHECK CRITICAL..INFO"
+        TEXT status "CHECK FAIL..MANUAL"
+        TEXT category
+        TEXT description
+        TEXT dedup_keys "JSON array"
+        TEXT benchmark_refs "JSON array"
+        TEXT raw_data "JSON object"
+        TEXT created_at
+    }
+
+    consolidated_findings {
+        TEXT finding_instance_id PK
+        TEXT engagement_id FK
+        TEXT finding_key
+        TEXT title
+        TEXT severity
+        TEXT status
+        TEXT category
+        TEXT description
+        TEXT sources "JSON SourceEvidence[]"
+        TEXT confidence "JSON ConfidenceScore"
+        TEXT benchmark_refs "JSON array"
+        TEXT root_cause
+        TEXT remediation
+        TEXT narrative
+        TEXT created_at
+        TEXT updated_at
+    }
+
+    coverage_records {
+        INTEGER id PK
+        TEXT engagement_id FK
+        TEXT control_id
+        TEXT tool_source
+        TEXT status "CHECK assessed.."
+        TEXT reason
+        TEXT created_at
+    }
+
+    tool_run_results {
+        INTEGER id PK
+        TEXT engagement_id FK
+        TEXT tool_source
+        TEXT started_at
+        TEXT completed_at
+        TEXT status
+        INTEGER finding_count
+        TEXT error
+        REAL duration_seconds
+    }
+
+    pipeline_events {
+        TEXT event_id PK
+        TEXT engagement_id FK
+        TEXT timestamp
+        TEXT event_type
+        TEXT actor
+        TEXT payload "JSON object"
+    }
+
+    overrides {
+        TEXT override_id PK
+        TEXT engagement_id FK
+        TEXT finding_id
+        TEXT field
+        TEXT old_value
+        TEXT new_value
+        TEXT reason
+        TEXT actor
+        TEXT created_at
+    }
+
+    stage_history {
+        INTEGER id PK
+        TEXT engagement_id FK
+        TEXT stage
+        TEXT started_at
+        TEXT completed_at
+        TEXT status
+        TEXT content_hash
+        TEXT error
+        REAL duration_seconds
+    }
+
+```
+
+**Notes on relationships.**
+
+- All child tables reference `engagements(engagement_id)` via SQLite
+  `REFERENCES`. The schema does not declare `ON DELETE CASCADE`; the
+  `EngagementRepo.delete()` method deletes from each child table explicitly
+  in dependency order
+  ([`engagement_repo.py:255-286`](../src/gxassessms/persistence/engagement_repo.py)).
+- `overrides.finding_id` references finding identity by string; it is not
+  declared as a SQL foreign key. The override may target either a parsed
+  `findings.finding_id` or a `consolidated_findings.finding_instance_id`,
+  depending on the field being overridden.
+- `pipeline_events.payload` is always a JSON object string. Event-type
+  payload shapes are documented in
+  [`pipeline/state.py`](../src/gxassessms/pipeline/state.py) (e.g.
+  `RawOutputIngestedPayload`).
+
+### Index strategy
+
+Defined alongside the schema:
+
+| Index | Columns | Use |
+|-------|---------|-----|
+| `idx_findings_severity_category` | `(severity, category)` | cross-engagement queries |
+| `idx_findings_engagement_severity` | `(engagement_id, severity)` | per-engagement filtering |
+| `idx_findings_tool_check` | `(tool_source, finding_key)` | adapter analytics |
+| `idx_pipeline_events_engagement_timestamp` | `(engagement_id, timestamp)` | journal ordering |
+| `idx_pipeline_events_engagement_event_type` | `(engagement_id, event_type)` | event filter |
+| `idx_consolidated_findings_engagement` | `(engagement_id)` | per-engagement reports |
+| `idx_coverage_records_engagement` | `(engagement_id)` | coverage join |
+| `idx_overrides_engagement` | `(engagement_id)` | override export |
+| `idx_stage_history_engagement` | `(engagement_id)` | timing analytics |
+| `idx_tool_run_results_engagement` | `(engagement_id)` | run metadata |
+
+## In-Memory Pydantic Models
+
+The pipeline lifts the persisted rows into typed Pydantic models defined in
+[`core/domain/models.py`](../src/gxassessms/core/domain/models.py). All
+datetime fields are validated as UTC by `ensure_utc()`
+([`core/config/datetime_utils.py`](../src/gxassessms/core/config/datetime_utils.py)).
+
+### Three Models for Tool Output
+
+Each adapter run produces three distinct shapes of the same data, each with
+a different responsibility and path representation:
+
+| Model | Lifecycle | Path representation |
+|-------|-----------|---------------------|
+| `CollectionOutput` | Returned by `adapter.collect()` | Platform-native absolute paths |
+| `ResolvedManifest` | Built by `confine_and_resolve()` for parse/coverage | Absolute paths, proven inside engagement dir |
+| `RawToolOutput` | Persisted to disk for replay | POSIX-relative canonical paths |
+
+`AdapterResult` and `CollectionResult` wrap these with `AdapterRunStatus`
+and any error string from a failed adapter run. A `SUCCESS` result must
+carry the wrapped output; the model validator enforces this
+([`models.py:230-244, 384-398`](../src/gxassessms/core/domain/models.py)).
+
+### Finding Lifecycle
+
+```mermaid
+classDiagram
+    class ToolObservation {
+        +str observation_id
+        +ToolSource tool
+        +str native_check_id
+        +str title
+        +str native_severity
+        +str native_status
+        +str|None native_category
+        +str description
+        +dict raw_data
+        +list[str] benchmark_refs
+    }
+
+    class Finding {
+        +str observation_id
+        +str native_check_id
+        +str finding_key
+        +ToolSource tool
+        +str title
+        +Severity severity
+        +FindingStatus status
+        +Category category
+        +str description
+        +list[str] dedup_keys
+        +list[str] benchmark_refs
+        +dict raw_data
+    }
+
+    class ConfidenceScore {
+        +float evidence_strength 0..1
+        +int corroborating_tools >=0
+        +float data_freshness 0..1
+        +ConfidenceProvenance provenance
+        +float overall 0..1
+    }
+
+    class SourceEvidence {
+        +ToolSource tool
+        +str check_id
+        +dict raw_data
+    }
+
+    class ConsolidatedFinding {
+        +str finding_instance_id
+        +str finding_key
+        +str title
+        +Severity severity
+        +FindingStatus status
+        +Category category
+        +str description
+        +list[SourceEvidence] sources
+        +ConfidenceScore confidence
+        +list[str] benchmark_refs
+        +str|None root_cause
+        +str|None remediation
+        +str|None narrative
+    }
+
+    class CoverageRecord {
+        +str control_id
+        +ToolSource tool
+        +CoverageStatus status
+        +str|None reason
+    }
+
+    ToolObservation --> Finding : NormalizationPolicy.normalize
+    Finding --> ConsolidatedFinding : ConsolidationRule.consolidate
+    ConsolidatedFinding *-- SourceEvidence : sources
+    ConsolidatedFinding *-- ConfidenceScore : confidence
+```
+
+### Identity Model
+
+Three explicit IDs with distinct lifecycles, none of which serve as both
+semantic identity and persistence key:
+
+| ID | Scope | Assigned by | Format |
+|----|-------|-------------|--------|
+| `observation_id` | Parse-time identity | `adapter.parse()` | `{tool}:{native_check_id}` (convention) |
+| `finding_key` | Cross-tool semantic identity | `NormalizationPolicy.normalize()` | `{namespace}:{control_id}` (e.g. `cis:m365:5.2.2.1`) |
+| `finding_instance_id` | DB instance identity | `FindingRepo.save_consolidated()` | UUID, never reused across engagements |
+
+The constraints `Finding.dedup_keys_must_be_nonempty` and
+`ConsolidatedFinding.sources_must_be_nonempty` enforce that every finding
+carries at least one dedup key and every consolidated finding cites at least
+one source evidence record
+([`models.py:128-175`](../src/gxassessms/core/domain/models.py)).
+
+### Engagement and Reporting Models
+
+```mermaid
+classDiagram
+    class AdapterResult {
+        +str adapter_name
+        +AdapterRunStatus status
+        +ResolvedManifest|None raw_output
+        +str|None error
+        +float duration_seconds
+    }
+
+    class CollectionResult {
+        +str adapter_name
+        +AdapterRunStatus status
+        +CollectionOutput|None collection_output
+        +str|None error
+        +float duration_seconds
+    }
+
+    class ToolRunResult {
+        +ToolSource tool
+        +datetime started_at
+        +datetime completed_at
+        +AdapterRunStatus status
+        +int finding_count
+        +str|None error
+    }
+
+    class ReportKeyStats {
+        +int total_findings
+        +int critical_count
+        +int high_count
+        +int medium_count
+        +int low_count
+        +int info_count
+        +int tools_run
+        +int tools_failed
+        +int controls_assessed
+        +int controls_not_assessed
+    }
+
+    class RemediationPhase {
+        +RemediationPhaseName phase
+        +str title
+        +str description
+        +list[str] findings "finding_instance_ids"
+        +int priority
+    }
+
+    class ReportPayload {
+        +str schema_version "default 1.0.0"
+        +str engagement_id
+        +str tenant_name
+        +str assessment_date
+        +list[str] tool_sources
+        +list[dict] findings
+        +list[dict] coverage
+        +dict narratives
+        +dict metadata
+    }
+
+    class AuthContext {
+        +SecretStr|None token
+        +dict[str,str] credential_refs
+        +datetime|None expires_at
+        +dict extra
+    }
+```
+
+`ReportPayload` is the published JSON contract handed to renderers. Its
+`schema_version` is the version a renderer declares compatibility with via
+`supported_payload_versions` (semver range, e.g. `>=1.0.0,<2.0.0`).
+Validation happens in `validate_version_compatibility()` before any renderer
+process is launched
+([`renderer_registry.py:79-99`](../src/gxassessms/reporting/renderer_registry.py)).
+
+`AuthContext.credential_refs` is validated to contain only lookup
+identifiers (env var names or `provider:key` form). Raw secret values are
+rejected at model validation time
+([`models.py:45-78`](../src/gxassessms/core/domain/models.py)).
+
+## Enumerations
+
+Defined in
+[`core/domain/enums.py`](../src/gxassessms/core/domain/enums.py). All are
+`StrEnum` for stable JSON serialization.
+
+| Enum | Members |
+|------|---------|
+| `Severity` | `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO` |
+| `FindingStatus` | `FAIL`, `PASS`, `WARNING`, `ERROR`, `N/A`, `MANUAL` |
+| `Category` | `Identity & Access`, `Data Protection`, `Device Management`, `Email & Collaboration`, `Infrastructure Security`, `Network Security`, `Logging & Monitoring`, `Cost Optimization`, `Operational Excellence`, `Compliance & Governance`, `Application Security` |
+| `AdapterRunStatus` | `SUCCESS`, `FAILED`, `SKIPPED`, `TIMEOUT` |
+| `CoverageStatus` | `assessed`, `partially_assessed`, `not_assessed` |
+| `ToolSource` | `ScubaGear`, `Maester`, `Monkey365`, `M365_Assess`, `Prowler`, `Steampipe`, `SecureScore`, `AzureAdvisor`, `DefenderCloud`, `M365DSC`, `IntuneExport`, `AzureResourceGraph`, `Custom`, `Manual` |
+| `EngagementState` | `CREATED`, `COLLECTING`, `COLLECTED`, `PARSING`, `PARSED`, `NORMALIZING`, `NORMALIZED`, `CONSOLIDATING`, `CONSOLIDATED`, `QA_REVIEW`, `QA_APPROVED`, `RENDERING`, `COMPLETE`, `FAILED` |
+
+`EngagementState` also exposes `can_transition_to()`,
+`assert_can_transition_to()`, and `is_terminal`. The transition map is a
+`MappingProxyType` defined at module scope; new states or transitions
+require editing the map directly
+([`enums.py:113-152`](../src/gxassessms/core/domain/enums.py)).
+
+## Event Journal Types
+
+`pipeline_events.event_type` is constrained to a literal-typed set
+([`state.py:28-45`](../src/gxassessms/pipeline/state.py)):
+
+```
+state_transition, override, ai_modification, rerun,
+manual_finding_added, lock_broken, stale_recovery,
+narrative_edit, narrative_approval, rerender, token_usage,
+manual_merge, raw_output_ingested
+```
+
+Event payloads are stored as JSON. Known typed payload shapes:
+
+| Event type | Payload shape |
+|-----------|---------------|
+| `state_transition` | `{from, to, content_hash?}` |
+| `override` | `{finding_id, field, new_severity, reason}` |
+| `manual_finding_added` | `{finding_key, severity}` |
+| `rerun` | `{from_state, to_state, target_stage, reason}` |
+| `raw_output_ingested` | `RawOutputIngestedPayload` (see [`state.py:95-103`](../src/gxassessms/pipeline/state.py)) |
+
+The journal is append-only; the orchestrator's `_emit_event()` is the only
+caller of `EventRepo.append()` from inside the public package.

--- a/docs/extension-points.md
+++ b/docs/extension-points.md
@@ -99,9 +99,11 @@ class PrerequisiteResult(TypedDict):
 Verify the tool is installed at an allowed version. For PowerShell adapters
 this typically validates against the adapter's
 `policy.py:MODULE_POLICY` via `_verification.check_module_prerequisites()`.
-Must not perform network I/O or authenticate. Called by
-`mseco preflight`, `mseco adapters check`, and (optionally) at the start of
-the `COLLECT` stage.
+Must not perform network I/O or authenticate. Called by `mseco preflight`
+and `mseco adapters check`; the runtime `COLLECT` stage (`stages.collect()`
+-> `_run_adapter()`) does not invoke this method, so operators must run
+preflight or adapter-check commands separately to surface prerequisite
+failures before kicking off a pipeline run.
 
 #### `authenticate(config) -> AuthContext | None`
 

--- a/docs/extension-points.md
+++ b/docs/extension-points.md
@@ -17,7 +17,7 @@ domain models referenced below see [data-model.md](data-model.md).
 |----------|-------------------|----------------|
 | [`ToolAdapter`](#tooladapter) | `gxassessms.adapters` | `tool_name`, `storage_slug`, `tool_source`, `capabilities`, six methods |
 | [`IngestCapableAdapter`](#ingestcapableadapter) | `gxassessms.adapters` | `ToolAdapter` + `"ingest"` cap + `default_schema_version` + `ingest_from_directory` |
-| [`ReportRenderer`](#reportrenderer) | `gxassessms.renderers` | `format`, `supported_payload_versions`, `render` |
+| [`ReportRenderer`](#reportrenderer) | `gxassessms.renderers` | `format`, `theme`, `supported_payload_versions`, `render` |
 | [`QAStrategy`](#qastrategy) | `gxassessms.qa_strategies` | `review_findings`, `generate_narratives` |
 | [`ConsolidationRule`](#consolidationrule) | `gxassessms.consolidation_rules` | `consolidate` |
 | [`NormalizationPolicy`](#normalizationpolicy) | `gxassessms.policies` (`normalization`) | `normalize` |

--- a/docs/extension-points.md
+++ b/docs/extension-points.md
@@ -1,0 +1,479 @@
+# Extension Points Reference
+
+GxAssessMS exposes every customization seam as a `Protocol` declared in
+[`core/contracts/types.py`](../src/gxassessms/core/contracts/types.py)
+(except `CredentialProvider`, which lives in
+[`core/contracts/credentials.py`](../src/gxassessms/core/contracts/credentials.py)).
+Implementations are discovered through `importlib.metadata` entry points.
+
+This document is the contract reference: signatures, return shapes,
+semantics, and registration. For pipeline context see
+[architecture.md](architecture.md) and [pipeline.md](pipeline.md). For the
+domain models referenced below see [data-model.md](data-model.md).
+
+## Index
+
+| Protocol | Entry-point group | Required attrs |
+|----------|-------------------|----------------|
+| [`ToolAdapter`](#tooladapter) | `gxassessms.adapters` | `tool_name`, `storage_slug`, `tool_source`, `capabilities`, six methods |
+| [`IngestCapableAdapter`](#ingestcapableadapter) | `gxassessms.adapters` | `ToolAdapter` + `"ingest"` cap + `default_schema_version` + `ingest_from_directory` |
+| [`ReportRenderer`](#reportrenderer) | `gxassessms.renderers` | `format`, `supported_payload_versions`, `render` |
+| [`QAStrategy`](#qastrategy) | `gxassessms.qa_strategies` | `review_findings`, `generate_narratives` |
+| [`ConsolidationRule`](#consolidationrule) | `gxassessms.consolidation_rules` | `consolidate` |
+| [`NormalizationPolicy`](#normalizationpolicy) | `gxassessms.policies` (`normalization`) | `normalize` |
+| [`ConsolidationPolicy`](#consolidationpolicy) | `gxassessms.policies` (`consolidation`) | `consolidate`, `merge_group` |
+| [`CredentialProvider`](#credentialprovider) | `gxassessms.credentials` | `get_credential`, `has_credential` |
+
+All `core/contracts/types.py` Protocols use `@runtime_checkable`, so
+`isinstance(impl, ProtocolName)` works for structural verification at test
+time.
+
+---
+
+## `ToolAdapter`
+
+Source: [`core/contracts/types.py:66-101`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class ToolAdapter(Protocol):
+    tool_name: str
+    storage_slug: str         # stable; [a-z0-9][a-z0-9-]*
+    tool_source: ToolSource
+    capabilities: frozenset[AdapterCapability]
+
+    def check_prerequisites(self) -> PrerequisiteResult: ...
+    def authenticate(self, config: EngagementConfig) -> AuthContext | None: ...
+    def collect(self, config: EngagementConfig, auth: AuthContext | None) -> CollectionOutput: ...
+    def validate_raw(self, raw: ResolvedManifest) -> None: ...
+    def parse(self, raw: ResolvedManifest) -> list[ToolObservation]: ...
+    def coverage(self, raw: ResolvedManifest) -> list[CoverageRecord]: ...
+```
+
+### Class attributes
+
+| Attribute | Type | Semantics |
+|-----------|------|-----------|
+| `tool_name` | `str` | Human-readable display name (e.g. `"ScubaGear"`). Non-empty. |
+| `storage_slug` | `str` | Filesystem namespace for raw output. Must match `[a-z0-9][a-z0-9-]*` and be unique across registered adapters. Used as the per-tool subdirectory under `<engagement_dir>/raw-output/`. |
+| `tool_source` | `ToolSource` | Identity enum used in `Finding.tool`, `SourceEvidence.tool`, and the persistence layer. Must be unique across registered adapters. |
+| `capabilities` | `frozenset[AdapterCapability]` | Declared capabilities. Drives which orchestrator phases call which methods. |
+
+### Capabilities
+
+`AdapterCapability` is a `Literal` type in `core/domain/constants.py`. The
+known values, with the methods each enables:
+
+| Capability | Required methods called by the pipeline |
+|-----------|----------------------------------------|
+| `collect` | `authenticate`, `collect` |
+| `parse` | `validate_raw`, `parse` |
+| `prerequisites` | `check_prerequisites` |
+| `shared_auth` | `authenticate` (result reusable across adapters) |
+| `coverage_export` | `coverage` |
+| `benchmark_mapping` | observation `benchmark_refs` populated |
+| `ingest` | `ingest_from_directory` (see [`IngestCapableAdapter`](#ingestcapableadapter)) |
+
+The runtime registry enforces a subset of these checks during discovery
+(see [`adapters/__init__.py`](../src/gxassessms/adapters/__init__.py)):
+
+- All members of `_REQUIRED_ATTRIBUTES` must be present on the class.
+- Instantiation must not raise.
+- `tool_name` must be a non-empty string.
+- `storage_slug` must be non-empty and match the slug pattern.
+- `storage_slug` and `tool_source` must each be unique across all registered
+  adapters.
+- If `"ingest"` is in `capabilities`, `ingest_from_directory` must be
+  callable and `default_schema_version` must be a non-empty string.
+
+### Method contracts
+
+#### `check_prerequisites() -> PrerequisiteResult`
+
+```python
+class PrerequisiteResult(TypedDict):
+    satisfied: bool
+    message: str
+```
+
+Verify the tool is installed at an allowed version. For PowerShell adapters
+this typically validates against the adapter's
+`policy.py:MODULE_POLICY` via `_verification.check_module_prerequisites()`.
+Must not perform network I/O or authenticate. Called by
+`mseco preflight`, `mseco adapters check`, and (optionally) at the start of
+the `COLLECT` stage.
+
+#### `authenticate(config) -> AuthContext | None`
+
+Resolve credentials and acquire any session needed by the tool. Return
+`None` when the tool authenticates itself (e.g. ScubaGear calls
+`Connect-MgGraph` internally). The returned `AuthContext` is passed back
+into `collect()`. `AuthContext.credential_refs` must contain only lookup
+identifiers; raw secrets must live on `AuthContext.token` (a `SecretStr`)
+or be resolved inside `collect()` via the registered `CredentialProvider`.
+
+#### `collect(config, auth) -> CollectionOutput`
+
+Run the tool and capture raw output. Returns a `CollectionOutput` whose
+`artifacts` list contains every file produced, each with its
+platform-native absolute path, canonical POSIX relative path, SHA-256, and
+encoding. The pipeline persists this output through `ArtifactManager`.
+
+Tool execution should use `subprocess.run(shell=False, ...)` with arguments
+as a list. Adapter-level timeouts should be enforced at the subprocess
+boundary (`subprocess.run(timeout=...)`).
+
+#### `validate_raw(raw) -> None`
+
+Structural validation at the tool-output boundary, called before any
+`parse()`. Verify that expected files exist in the manifest, that JSON
+payloads have expected top-level keys, and that the result is not
+suspiciously empty. Raise `RawOutputValidationError` on any structural
+mismatch. The pipeline treats this as a fail-fast: a validation failure
+fails the PARSE stage; downstream stages do not run.
+
+#### `parse(raw) -> list[ToolObservation]`
+
+Transform the tool-native output into `ToolObservation` records. One adapter
+parse = one list. Severity, status, and category fields hold the tool's
+native string values; normalization happens in the policy layer.
+
+#### `coverage(raw) -> list[CoverageRecord]`
+
+Extract per-control assessment status. Called only for adapters that
+declare `"coverage_export"` in `capabilities`. Returns one record per
+control the tool evaluated, with status `assessed`, `partially_assessed`,
+or `not_assessed` and an optional human-readable reason.
+
+### Reference adapter
+
+[`adapters/scubagear/adapter.py`](../src/gxassessms/adapters/scubagear/adapter.py)
+is the reference implementation. The package layout per adapter is fixed:
+
+```
+adapters/<name>/
+    __init__.py    # exports the class
+    adapter.py     # Protocol implementation
+    parser.py      # native output parsing
+    mappings.py    # severity / category / dedup-key tables
+    policy.py      # MODULE_POLICY (PowerShell adapters only)
+    fixtures/      # representative test data
+```
+
+---
+
+## `IngestCapableAdapter`
+
+Source: [`core/contracts/types.py:104-122`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class IngestCapableAdapter(ToolAdapter, Protocol):
+    default_schema_version: str
+
+    def ingest_from_directory(
+        self,
+        source_dir: Path,
+        *,
+        schema_version: str,
+        timestamp: datetime,
+    ) -> CollectionOutput: ...
+```
+
+Optional capability for adapters that can construct a `CollectionOutput`
+from operator-supplied raw output (the tool was run elsewhere, the client
+delivered a results bundle, or the adapter author wants to replay against
+captured fixtures).
+
+Declared by including `"ingest"` in `capabilities`, defining
+`default_schema_version` as a class attribute, and implementing
+`ingest_from_directory`. The registry rejects adapters that fail any of
+these requirements.
+
+`mseco ingest` is the CLI entry point; it calls `ingest_from_directory`,
+persists the resulting artifacts through `ArtifactManager`, and records a
+`raw_output_ingested` event in the journal.
+
+---
+
+## `ReportRenderer`
+
+Source: [`core/contracts/types.py:125-131`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class ReportRenderer(Protocol):
+    format: str
+    theme: str
+    supported_payload_versions: str    # semver range, e.g. ">=1.0.0,<2.0.0"
+
+    def render(self, payload: ReportPayload, output_dir: Path) -> Path: ...
+```
+
+### Class attributes
+
+| Attribute | Semantics |
+|-----------|-----------|
+| `format` | Output format identifier (e.g. `"docx"`, `"pptx"`, `"html"`). Used by `RendererRegistry.get_by_format()` to group renderers. |
+| `theme` | Free-form theme identifier. The registry does not interpret this; renderers may surface it in output filenames or metadata. |
+| `supported_payload_versions` | Comma-separated semver constraints (`>=`, `<=`, `>`, `<`, `==`). Validated by `validate_version_compatibility()` before render is invoked. |
+
+### `render(payload, output_dir) -> Path`
+
+Render `payload` to a file inside `output_dir`. Return the path actually
+written. The caller (`RendererRegistry` invoking `NodeRenderer`) is
+responsible for:
+
+1. Validating payload version compatibility (raises `PayloadVersionError`).
+2. Writing `payload.json` and `constants.json` into a temp directory.
+3. Invoking the Node.js entry point with `--payload`, `--output`, and
+   `--constants` arguments.
+4. Wrapping any non-zero exit, missing output, or empty output as
+   `ReportError`.
+
+The bundled implementation `NodeRenderer` validates two further conditions
+at construction time (catches problems before `RENDER` rather than during):
+
+- `render.js` exists in the renderer package path.
+- `node` is available on `PATH` and runs `node --version` successfully.
+
+Either failure raises `RendererDependencyError`. This is what
+`mseco preflight` step 4 checks for every registered renderer
+([`renderer_registry.py:159-169`](../src/gxassessms/reporting/renderer_registry.py)).
+
+A Python-only renderer is not required to use `NodeRenderer`. A
+class implementing `render()` directly is fine; the Protocol is structural.
+
+### Bundled renderer
+
+`BasicDocxRenderer` (entry-point `basic_docx`) wraps a Node.js renderer
+package shipped alongside the public package. It produces a plain `.docx`
+summary suitable for engagement archives.
+
+---
+
+## `QAStrategy`
+
+Source: [`core/contracts/types.py:134-154`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class QAStrategy(Protocol):
+    is_noop: bool = False
+
+    def review_findings(self, findings: list[ConsolidatedFinding]) -> list[QAResult]: ...
+    def generate_narratives(
+        self, findings: list[ConsolidatedFinding], config: EngagementConfig
+    ) -> Narratives: ...
+```
+
+The `QA_REVIEW` stage calls `review_findings()`. If `is_noop` is `True` the
+orchestrator auto-advances `QA_REVIEW -> QA_APPROVED` without further
+gating; otherwise the engagement parks at `QA_REVIEW` for downstream
+approval.
+
+### Result shapes
+
+```python
+class QAResult(TypedDict):
+    finding_instance_id: str
+    adjusted_severity: Severity | None   # None means "no change recommended"
+    confidence_delta: float              # Positive = increased confidence
+    narrative: str | None                # Per-finding text, if generated
+    flags: list[str]                     # e.g. ["budget_exhausted",
+                                         #       "low_confidence",
+                                         #       "potential_duplicate",
+                                         #       "qa_quality_failed"]
+
+class Narratives(TypedDict):
+    executive_summary: str
+    roadmap: str
+    findings_narrative: str | None
+    flags: NotRequired[list[str]]
+```
+
+`flags` is a free-form list of string tokens. The pipeline does not require
+specific values; downstream consumers (reports, review interfaces) decide
+how to surface them.
+
+### Optional class attributes
+
+| Attribute | Default | Effect |
+|-----------|---------|--------|
+| `is_noop` | `False` | When `True`, auto-advance state machine through QA |
+| `priority` | `0` | Used during selection when multiple strategies are registered; higher wins. The `--qa-strategy <name>` CLI flag overrides priority. |
+
+### Selection rules
+
+1. `--qa-strategy <name>` on the CLI loads that exact entry point or fails.
+2. Otherwise, the highest-`priority` strategy among loaded entry points
+   wins. Ties resolve by `importlib.metadata` discovery order.
+3. Convention: ship `priority = 0` for any default/no-op strategy and
+   `priority >= 100` for any production strategy that wants to be preferred
+   automatically when installed.
+
+### Bundled strategy
+
+`NoOpQAStrategy` (entry-point `noop`,
+[`qa/noop.py`](../src/gxassessms/qa/noop.py)) returns no review results
+and empty narratives. It satisfies the Protocol so the pipeline can run
+end-to-end without any external dependency.
+
+---
+
+## `ConsolidationRule`
+
+Source: [`core/contracts/types.py:157-168`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class ConsolidationRule(Protocol):
+    def consolidate(self, findings: list[Finding]) -> list[ConsolidatedFinding]: ...
+```
+
+### Invariants
+
+Property-based tests
+([`tests/property/`](../tests/property/) -- see spec Section 11) enforce:
+
+1. `len(output) <= len(input)` -- never produce more groups than inputs.
+2. Every input `Finding` appears in exactly one output group.
+3. Severity never decreases during merge.
+4. No `dedup_key` appears in more than one consolidated finding.
+
+### Bundled rule
+
+`DefaultConsolidationRule` ([`consolidation/rules.py`](../src/gxassessms/consolidation/rules.py))
+composes `UnionFindDedup` (grouping) with a `ConsolidationPolicy`
+implementation (merging). To swap one piece, register a new rule via
+`gxassessms.consolidation_rules`; to swap only the merge step, register a
+new policy via `gxassessms.policies`.
+
+---
+
+## `NormalizationPolicy`
+
+Source: [`core/contracts/types.py:171-185`](../src/gxassessms/core/contracts/types.py)
+
+```python
+@runtime_checkable
+class NormalizationPolicy(Protocol):
+    def normalize(
+        self,
+        observations: list[ToolObservation],
+        adapter_severity_map: dict[tuple[str, str], str],
+        adapter_category_map: dict[str, str],
+        adapter_dedup_keys: dict[str, str],
+    ) -> list[Finding]: ...
+```
+
+Transform tool-native `ToolObservation` records into normalized `Finding`
+records by applying severity, category, and dedup-key mapping. The
+orchestrator resolves the adapter-specific mapping tables (declarative
+data in `adapters/<name>/mappings.py`) and passes them through.
+
+`NormalizationPolicy` implementations must not perform I/O. YAML rule data
+is loaded by `core/config/` and passed through the implementation's
+constructor as a plain dict.
+
+The default implementation in
+[`policy/normalization.py`](../src/gxassessms/policy/normalization.py)
+resolves severity in three passes (adapter-specific table, default rules,
+fallback to a domain-status-driven default).
+
+---
+
+## `ConsolidationPolicy`
+
+Source: [`policy/consolidation.py:34-52`](../src/gxassessms/policy/consolidation.py)
+
+```python
+@runtime_checkable
+class ConsolidationPolicy(Protocol):
+    def consolidate(self, findings: list[Finding]) -> list[ConsolidatedFinding]: ...
+    def merge_group(
+        self, finding_key: str, findings: list[Finding]
+    ) -> ConsolidatedFinding: ...
+```
+
+Two usage patterns:
+
+- `consolidate()` -- full pipeline: receives raw findings and returns a
+  flat consolidated list. Bypasses the dedup engine and groups by
+  `finding_key` directly.
+- `merge_group()` -- called by `DefaultConsolidationRule` after the
+  union-find dedup engine has built groups. Reconciles severity and status
+  across the group, computes `ConfidenceScore`, builds the `SourceEvidence`
+  list, and returns one `ConsolidatedFinding`.
+
+Contract: `merge_group()` requires `findings` to be non-empty.
+Implementations must raise `ConsolidationError` if called with an empty
+list.
+
+---
+
+## `CredentialProvider`
+
+Source: [`core/contracts/credentials.py:13-23`](../src/gxassessms/core/contracts/credentials.py)
+
+```python
+@runtime_checkable
+class CredentialProvider(Protocol):
+    def get_credential(self, key: str) -> str: ...
+    def has_credential(self, key: str) -> bool: ...
+```
+
+Resolve credential lookup keys to actual secret values. Implementations
+must:
+
+- Raise `KeyError` from `get_credential` if the key cannot be resolved.
+- Return `False` from `has_credential` for unresolvable keys (without
+  raising).
+- Never log resolved values or write them to disk.
+
+Adapter code calls `provider.get_credential(key)` only inside the
+narrowest possible scope (`collect()` or `authenticate()`), immediately
+hands the resulting string to the underlying SDK or subprocess, and never
+stores it on `self`.
+
+### Bundled provider
+
+`EnvVarProvider` (entry-point `env_var`) reads from environment variables.
+The `client_secret_env`, `client_id_env`, and similar fields in the
+engagement config carry the env var *name*; resolution happens at run
+time.
+
+---
+
+## Discovery and Validation
+
+All discovery flows go through
+[`registry.discover_entry_points()`](../src/gxassessms/registry.py), which
+returns a `DiscoveryResult` containing successfully loaded plugins plus a
+list of `DiscoveryError` records for entry points that failed to import.
+`ImportError` and `AttributeError` are caught individually so one broken
+plugin cannot prevent the others from loading; any other exception
+propagates.
+
+Plugin-type-specific validation lives in the registry module for that type
+(e.g. `adapters/__init__.py` for adapters,
+`reporting/renderer_registry.py` for renderers). Failed validation
+produces a `DiscoveryError` and excludes the plugin from the active
+registry; it never raises.
+
+`mseco preflight` reports both the loaded plugins and the discovery /
+validation errors so problems are surfaced before a client engagement
+runs.
+
+## Versioning Discipline
+
+Pre-1.0 the public API is unstable. After 1.0:
+
+- Adding optional methods to a Protocol is a minor change.
+- Renaming or removing methods, changing signatures, or tightening type
+  parameters is a major change.
+- `ReportPayload.schema_version` follows additive-fields = minor /
+  removing-or-renaming = major.
+
+See the architecture spec's "Formal Compatibility Policy" section
+(deferred to v1) for the longer-form rules.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -99,14 +99,13 @@ sequenceDiagram
 
     CLI->>Orch: run(engagement_id, config,<br/>adapters, policies,<br/>qa_strategy, renderers)
     Orch->>Runner: run_stages(start_stage=COLLECT)
+    Runner->>Lock: hold(engagement_id)
+    activate Lock
     Runner->>Repo: get(engagement_id) — current state
     Repo-->>Runner: state
     Note over Runner: detect_stale_running()<br/>or transition CREATED → COLLECTING
 
     loop per stage in stage_order
-        Runner->>Lock: hold(engagement_id)
-        activate Lock
-
         Runner->>Repo: emit "state_transition" (X → X_ING)
         Runner->>Stage: stage_fn(ctx, plugins)
         Stage->>Plugin: invoke (parallel for collect)
@@ -136,21 +135,22 @@ sequenceDiagram
             Runner->>Repo: emit state_transition (RENDERING → COMPLETE)
         end
 
-        Lock-->>Runner: release
-        deactivate Lock
-
         opt stop_stage reached
+            Lock-->>Runner: release
+            deactivate Lock
             Runner-->>Orch: return early
         end
     end
 
+    Lock-->>Runner: release
     Orch-->>CLI: return
 ```
 
 Key invariants:
 
-- **Lock scope.** Each stage acquires the lock for its duration; the lock is
-  released between stages so a separate process can inspect engagement state.
+- **Lock scope.** `run_stages()` acquires the engagement lock once around
+  the entire stage loop and holds it until the function returns, so no other
+  process can interleave stage execution against the same engagement.
   ([`_runner.py`](../src/gxassessms/pipeline/_runner.py))
 - **Partial collection.** Failed adapters produce a `CollectionResult` with
   status `FAILED`, `TIMEOUT`, or `SKIPPED`; downstream stages skip them and

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,329 @@
+# Pipeline Lifecycle
+
+The pipeline executes six stages -- COLLECT, PARSE, NORMALIZE, CONSOLIDATE,
+QA_REVIEW, RENDER -- against a single engagement. Each stage is a pure
+function in [`pipeline/stages.py`](../src/gxassessms/pipeline/stages.py); the
+`Orchestrator` in [`pipeline/orchestrator.py`](../src/gxassessms/pipeline/orchestrator.py)
+calls them through `_runner.run_stages()` and persists results between calls.
+
+This document covers four flows:
+
+1. Plugin discovery and entry-point registration
+2. End-to-end orchestrator run
+3. Tool-adapter invocation lifecycle inside `COLLECT` and `PARSE`
+4. Consolidation pipeline data flow
+
+For state-machine details and resume rules see
+[architecture.md](architecture.md#pipeline-lifecycle).
+
+---
+
+## 1. Plugin Discovery and Entry-Point Registration
+
+All extension types follow the same shape: an entry-point group, a generic
+discovery pass via [`registry.discover_entry_points()`](../src/gxassessms/registry.py),
+and a type-specific validation pass that excludes invalid entries with a
+logged warning rather than crashing. The adapter registry adds cross-adapter
+constraint checks (duplicate slug / tool_source detection, slug format).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as cli/_helpers
+    participant Reg as adapters/__init__<br/>discover_adapters
+    participant Disc as registry<br/>discover_entry_points
+    participant IM as importlib.metadata
+    participant EP as Adapter class<br/>(entry point)
+
+    CLI->>Reg: discover_adapters()
+    Reg->>Disc: discover_entry_points("gxassessms.adapters")
+    Disc->>IM: entry_points(group=...)
+    IM-->>Disc: iterable of EntryPoint
+    loop per entry point
+        Disc->>EP: ep.load()
+        alt load succeeds
+            EP-->>Disc: adapter class
+            Disc-->>Disc: plugins[name] = class
+        else ImportError or AttributeError
+            EP-->>Disc: exception
+            Disc-->>Disc: errors.append(DiscoveryError)
+        end
+    end
+    Disc-->>Reg: DiscoveryResult(plugins, errors)
+
+    loop per loaded class
+        Reg->>Reg: _validate_adapter(name, cls)
+        Note over Reg: REQUIRED_ATTRIBUTES present?<br/>cls() instantiates?<br/>tool_name non-empty?<br/>If "ingest" cap: ingest_from_directory<br/>+ default_schema_version present?
+        alt valid
+            Reg-->>Reg: adapters[name] = cls
+        else invalid
+            Reg-->>Reg: validation_errors.append(...)
+        end
+    end
+    Reg->>Reg: _validate_registry_constraints(adapters)
+    Note over Reg: storage_slug format,<br/>uniqueness,<br/>tool_source uniqueness
+    Reg-->>CLI: AdapterRegistry(adapters, validation_errors)
+```
+
+Renderers follow the same pattern via
+[`reporting/renderer_registry.py:RendererRegistry.discover()`](../src/gxassessms/reporting/renderer_registry.py).
+Renderer instantiation also performs dependency-chain validation:
+`NodeRenderer.__init__` checks that `render.js` exists and that Node.js is
+on the PATH, raising `RendererDependencyError` if either is missing
+([`renderer_registry.py:159-169`](../src/gxassessms/reporting/renderer_registry.py)).
+
+QA strategies, policies, consolidation rules, and credential providers are
+discovered the same way through `discover_entry_points()` with their
+respective group names (see [architecture.md](architecture.md#extension-points)).
+
+---
+
+## 2. Orchestrator Run Lifecycle
+
+`Orchestrator.run()` and `Orchestrator.run_from()` both delegate to
+`_runner.run_stages()`, which walks the stage list starting at a given
+stage. Between every stage the runner persists outputs through the
+appropriate repository and emits a `state_transition` event to the journal.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as cli/commands/run
+    participant Orch as Orchestrator
+    participant Lock as EngagementLock
+    participant Runner as _runner.run_stages
+    participant Stage as pipeline.stages
+    participant Repo as Repos<br/>(Engagement, Finding,<br/>Coverage, Event)
+    participant Art as ArtifactManager
+    participant Plugin as Adapters /<br/>Policies / QA /<br/>Renderers
+
+    CLI->>Orch: run(engagement_id, config,<br/>adapters, policies,<br/>qa_strategy, renderers)
+    Orch->>Runner: run_stages(start_stage=COLLECT)
+    Runner->>Repo: get(engagement_id) — current state
+    Repo-->>Runner: state
+    Note over Runner: detect_stale_running()<br/>or transition CREATED → COLLECTING
+
+    loop per stage in stage_order
+        Runner->>Lock: hold(engagement_id)
+        activate Lock
+
+        Runner->>Repo: emit "state_transition" (X → X_ING)
+        Runner->>Stage: stage_fn(ctx, plugins)
+        Stage->>Plugin: invoke (parallel for collect)
+        Plugin-->>Stage: results / observations / findings / etc.
+        Stage-->>Runner: stage output
+
+        alt COLLECT
+            Runner->>Art: save_raw_outputs()
+            Runner->>Repo: emit state_transition (COLLECTING → COLLECTED)
+        else PARSE
+            Runner->>Art: confine_and_resolve()
+            Runner->>Repo: save coverage records
+            Runner->>Repo: emit state_transition (PARSING → PARSED)
+        else NORMALIZE
+            Runner->>Repo: save_parsed(findings)
+            Runner->>Repo: emit state_transition (NORMALIZING → NORMALIZED)
+        else CONSOLIDATE
+            Runner->>Repo: save_consolidated(findings)
+            Runner->>Repo: emit state_transition (CONSOLIDATING → CONSOLIDATED)
+        else QA_REVIEW
+            opt strategy.is_noop
+                Runner->>Repo: auto-advance (QA_REVIEW → QA_APPROVED)
+            end
+        else RENDER
+            Runner->>Plugin: renderer.render(payload, output_dir)
+            Plugin-->>Runner: written path
+            Runner->>Repo: emit state_transition (RENDERING → COMPLETE)
+        end
+
+        Lock-->>Runner: release
+        deactivate Lock
+
+        opt stop_stage reached
+            Runner-->>Orch: return early
+        end
+    end
+
+    Orch-->>CLI: return
+```
+
+Key invariants:
+
+- **Lock scope.** Each stage acquires the lock for its duration; the lock is
+  released between stages so a separate process can inspect engagement state.
+  ([`_runner.py`](../src/gxassessms/pipeline/_runner.py))
+- **Partial collection.** Failed adapters produce a `CollectionResult` with
+  status `FAILED`, `TIMEOUT`, or `SKIPPED`; downstream stages skip them and
+  log a warning. ([`stages.parse()`](../src/gxassessms/pipeline/stages.py:161-207))
+- **Approval freshness for RENDER.** Before entering RENDER, the orchestrator
+  walks the journal: if any upstream stage (`COLLECT`, `PARSE`, `NORMALIZE`,
+  `CONSOLIDATE`) was re-run after the most recent `QA_APPROVED` event, it
+  raises `PipelineError`.
+  ([`orchestrator._verify_qa_for_render`](../src/gxassessms/pipeline/orchestrator.py:372-415))
+- **Resume.** `determine_resume_stage()` maps the current state to the next
+  stage to run. `PARSED -> PARSE` (not `NORMALIZE`) because observations
+  aren't persisted; replay re-parses from manifests.
+  ([`orchestrator.py:465-514`](../src/gxassessms/pipeline/orchestrator.py))
+
+---
+
+## 3. Tool-Adapter Invocation Lifecycle
+
+Each adapter goes through a fixed sequence inside `COLLECT` and `PARSE`. The
+orchestrator never calls adapter methods out of order.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Run as stages.collect
+    participant Pool as ThreadPoolExecutor
+    participant Ad as ToolAdapter
+    participant CP as CredentialProvider
+    participant FS as Filesystem<br/>(raw output)
+
+    Run->>Pool: submit(_run_adapter) per adapter
+
+    par per adapter (concurrent)
+        Pool->>Ad: check_prerequisites()
+        Note over Ad: validates module<br/>provenance / version
+        Ad-->>Pool: PrerequisiteResult
+
+        opt prerequisites satisfied
+            Pool->>Ad: authenticate(config)
+            opt adapter resolves credentials
+                Ad->>CP: get_credential(key)
+                CP-->>Ad: secret value (SecretStr)
+            end
+            Ad-->>Pool: AuthContext | None
+
+            Pool->>Ad: collect(config, auth)
+            Ad->>FS: write tool output<br/>(PowerShell / API / CLI)
+            Ad-->>Pool: CollectionOutput<br/>(artifacts, schema_version)
+        end
+    end
+
+    Pool-->>Run: list[CollectionResult]<br/>(SUCCESS / FAILED / TIMEOUT / SKIPPED)
+
+    Note over Run: stages.parse() phase begins
+    loop per SUCCESS result
+        Run->>Ad: validate_raw(manifest)
+        alt validation passes
+            Ad-->>Run: ok
+            Run->>Ad: parse(manifest)
+            Ad-->>Run: list[ToolObservation]
+            opt "coverage_export" in adapter.capabilities
+                Run->>Ad: coverage(manifest)
+                Ad-->>Run: list[CoverageRecord]
+            end
+        else validation fails
+            Ad--XRun: RawOutputValidationError
+            Note over Run: stage fails fast,<br/>journal records FAILED
+        end
+    end
+```
+
+`CollectionOutput` carries platform-native absolute paths. Before the parse
+stage runs, `confine_and_resolve()` rewrites those paths into
+`ResolvedManifest` instances whose `file_manifest` entries are absolute paths
+proven to live inside the engagement directory. Manifests that fail
+confinement raise `ManifestConfinementError`.
+
+### Optional: Operator Ingest
+
+An adapter that declares `"ingest"` in its capability set and implements the
+`IngestCapableAdapter` Protocol can also be fed pre-collected output via
+`mseco ingest`:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as cli/commands/ingest
+    participant Orch as Orchestrator
+    participant Ad as IngestCapableAdapter
+    participant Art as ArtifactManager
+    participant Journal as EventRepo
+
+    CLI->>Ad: ingest_from_directory(source_dir,<br/>schema_version, timestamp)
+    Ad-->>CLI: CollectionOutput
+    CLI->>Art: save_raw_outputs([CollectionResult])
+    CLI->>Orch: record_raw_output_ingested(<br/>engagement_id, tool_slug,<br/>source_path, replaced)
+    Orch->>Journal: append "raw_output_ingested" event
+```
+
+After ingest, the operator runs `mseco replay <engagement_id>` to re-enter
+the pipeline at PARSE.
+
+---
+
+## 4. Consolidation Pipeline Data Flow
+
+CONSOLIDATE deduplicates findings across tools. The default implementation
+splits the work between a tool-agnostic union-find dedup engine and a
+policy-driven merge step.
+
+```mermaid
+flowchart TB
+    start([list&lt;Finding&gt; from NORMALIZE]) --> empty{empty?}
+    empty -- yes --> done([list&lt;ConsolidatedFinding&gt;])
+    empty -- no --> rule[DefaultConsolidationRule.consolidate]
+
+    rule --> dedup[UnionFindDedup.group]
+    dedup --> ds[_DisjointSet<br/>indexed by Finding position]
+    ds --> key_index[build key → indices map<br/>filter empty/whitespace keys]
+    key_index --> union[union all indices<br/>sharing a key]
+    union --> warn{key shared by<br/>&gt;50 findings?}
+    warn -- yes --> log_warn[log WARNING<br/>possible adapter<br/>misconfiguration]
+    warn -- no --> collect
+    log_warn --> collect[collect groups by<br/>disjoint-set root]
+    collect --> groups([list&lt;list&lt;Finding&gt;&gt;])
+
+    groups --> canon[select canonical finding_key<br/>per group]
+    canon --> tie{single<br/>unique key?}
+    tie -- yes --> use[use that key]
+    tie -- no --> pick[pick highest severity,<br/>tiebreak lex max]
+
+    use --> merge
+    pick --> merge[ConsolidationPolicy.merge_group]
+
+    merge --> severity[reconcile severity<br/>across sources]
+    merge --> status[reconcile status]
+    merge --> conf[compute ConfidenceScore]
+    merge --> sources[build SourceEvidence list<br/>from each Finding]
+
+    severity --> cf[ConsolidatedFinding]
+    status --> cf
+    conf --> cf
+    sources --> cf
+
+    cf --> done
+```
+
+Highlights:
+
+- **Union-find with iterative path compression.** No recursion -- safe for
+  deep dedup chains.
+  ([`dedup.py:38-47`](../src/gxassessms/consolidation/dedup.py))
+- **Whitespace filtering.** Empty or whitespace-only dedup keys are
+  filtered out before grouping. A finding with no valid key remaining gets
+  its own isolated group and a WARNING log line.
+- **Cardinality warning.** If a single key joins more than 50 findings, the
+  engine logs a warning -- usually a sign that an adapter is using too
+  generic a `finding_key` rule.
+- **Canonical key selection.** Within a group, the policy picks one
+  `finding_key` to represent the merged finding. The default rule prefers
+  the key from the highest-severity contributor and breaks ties
+  lexicographically for determinism.
+  ([`rules.py:93-119`](../src/gxassessms/consolidation/rules.py))
+
+The dedup engine has no knowledge of `ConsolidationPolicy`; the policy has
+no knowledge of how groups are formed. The bridge sits only in
+`DefaultConsolidationRule`. Either piece can be replaced via the
+`gxassessms.consolidation_rules` and `gxassessms.policies` entry-point groups.
+
+## See also
+
+- [extension-points.md](extension-points.md) -- full Protocol method
+  signatures
+- [data-model.md](data-model.md) -- ER diagram for the persisted state
+- [configuration.md](configuration.md) -- engagement YAML reference
+- [runbook.md](runbook.md) -- partial-failure triage and resume scenarios

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -163,8 +163,8 @@ Score. Pass the appropriate slug with `--tool`:
 **Not supported:** Monkey365 and M365-Assess ingest is not supported.
 Both tools embed collection timestamps inside their output in a way that
 cannot be reliably disambiguated from processing time (freshness
-ambiguity). Use live collection for these tools or contact Guardantix
-support for guidance.
+ambiguity). Use live collection for these tools or consult the adapter's
+own documentation for guidance.
 
 **Resolution:**
 
@@ -244,14 +244,14 @@ support for guidance.
 
 ---
 
-## 4. AI QA Budget Exhaustion Mid-Pipeline
+## 4. QA Token Budget Exhaustion Mid-Pipeline
 
 **Symptom:** Pipeline completes CONSOLIDATED stage but QA_REVIEW fails
 with `TokenBudgetExhaustedError`.
 
-**Likely cause:** Large engagement with many findings. The AI QA layer
-tracks token usage across all tasks (severity review, dedup review,
-root cause, narratives). Budget is configured per engagement.
+**Likely cause:** Large engagement with many findings. A non-noop
+`QAStrategy` plugin that tracks token usage has reached its configured
+per-engagement budget. Budget is configured per engagement.
 
 **Diagnostic steps:**
 
@@ -281,8 +281,8 @@ root cause, narratives). Budget is configured per engagement.
   mseco run <config.yaml> --engagement-id <id> --force-stage QA_REVIEW
   ```
 
-- **Use no-op QA:** If AI QA is not critical for this engagement, select
-  the noop strategy and skip AI-generated narratives:
+- **Use no-op QA:** If automated QA is not critical for this engagement,
+  select the noop strategy and skip generated narratives:
 
   ```
   mseco run <config.yaml> --engagement-id <id> \
@@ -291,7 +291,7 @@ root cause, narratives). Budget is configured per engagement.
 
 - **Partial QA results:** If severity review and dedup review completed
   but narratives did not, the partial results persist. The operator can
-  write narratives manually in the review UI and approve QA there.
+  write narratives manually through their QA workflow and approve QA there.
 
 ---
 
@@ -461,9 +461,9 @@ linked, payload contains unexpected shapes, or renderer JS bug.
   cd report-renderers/basic && npm install
   ```
 
-  Branded renderers installed via plugins typically link their dependencies
-  through `file:` references in the renderer's own `package.json`; ensure
-  those linked packages are installed.
+  Renderers installed via extension plugins typically link their
+  dependencies through `file:` references in the renderer's own
+  `package.json`; ensure those linked packages are installed.
 
 - **Renderer bug:** Once fixed, re-render the engagement:
 
@@ -475,11 +475,11 @@ linked, payload contains unexpected shapes, or renderer JS bug.
 
 ## 9. Concurrent CLI / UI Conflict Resolution
 
-**Symptom:** An installed review UI shows "Engagement locked by another
-process" or CLI reports a lock acquisition timeout.
+**Symptom:** A review interface plugin shows "Engagement locked by
+another process" or CLI reports a lock acquisition timeout.
 
-**Likely cause:** Both the CLI (`mseco run`) and a review UI plugin are
-attempting state-mutating operations on the same engagement
+**Likely cause:** Both the CLI (`mseco run`) and a review interface
+plugin are attempting state-mutating operations on the same engagement
 simultaneously. The advisory `filelock` serializes these operations.
 
 **Diagnostic steps:**
@@ -508,9 +508,9 @@ simultaneously. The advisory `filelock` serializes these operations.
   subcommand -- lock management is handled by `filelock` and manual
   cleanup.)
 
-- **Prevention:** Do not run `mseco run` while a review UI has active
-  pipeline re-render operations in flight. Use the review UI's own
-  pipeline controls when the UI is open.
+- **Prevention:** Do not run `mseco run` while a review interface has
+  active pipeline re-render operations in flight. Use that interface's
+  own pipeline controls when it is open.
 
 ---
 
@@ -548,7 +548,7 @@ proof that all assessment data has been deleted.
 **Caveats:**
 
 - Purge is irreversible. There is no undo.
-- Longitudinal snapshots referencing the purged engagement retain a
+- Trend-tracking snapshots referencing the purged engagement retain a
   `purged` marker instead of actual data. Cross-engagement analytics no
   longer include the purged engagement's findings.
 - The audit manifest itself may have its own retention policy


### PR DESCRIPTION
## Summary

Adds four new technical documents to `docs/`:

- **architecture.md** — layered overview with a Mermaid component diagram plus the extension-point group → Protocol map.
- **pipeline.md** — plugin discovery, orchestrator run lifecycle, tool-adapter invocation, and consolidation data flow as sequence and flowchart diagrams.
- **data-model.md** — ER diagram for the engagement DB and class diagrams for the in-memory Pydantic finding lifecycle.
- **extension-points.md** — full Protocol reference covering `ToolAdapter`, `IngestCapableAdapter`, `ReportRenderer`, `QAStrategy`, `ConsolidationRule`, `NormalizationPolicy`, `ConsolidationPolicy`, and `CredentialProvider`.

Also retargets a few `runbook.md` scenarios at the framework's actual extension-point vocabulary (QA strategy, renderer plugins, review interface) so they read as generic operational guidance rather than naming specific extension implementations.

Every Protocol named in the docs is verified against `src/`. All Mermaid blocks use the standard `flowchart` / `sequenceDiagram` / `erDiagram` / `classDiagram` types and are balanced (open/close fence counts match in every doc).

## Test plan

- [ ] Render the four new docs on GitHub and confirm each Mermaid block renders without syntax errors.
- [ ] Confirm every link in `architecture.md` resolves to one of the other new docs or an existing doc.
- [ ] `python -c "import gxassessms"` succeeds in the repo venv (verified locally before PR).